### PR TITLE
[#4] [Android] Setup Firebase Distribution & CD workflows

### DIFF
--- a/.github/workflows/android_deploy_production_build.yml
+++ b/.github/workflows/android_deploy_production_build.yml
@@ -1,0 +1,65 @@
+name: Android - Deploy Production build to Firebase
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy_android_production_to_firebase:
+    name: Deploy android production to Firebase
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Google Services
+        env:
+          ANDROID_PRODUCTION_GOOGLE_SERVICES_JSON: ${{ secrets.ANDROID_PRODUCTION_GOOGLE_SERVICES_JSON }}
+        run: |
+          mkdir -p android/src/production
+          echo $ANDROID_PRODUCTION_GOOGLE_SERVICES_JSON > android/src/production/google-services.json
+
+      - name: Setup Android release signing
+        env:
+          ANDROID_RELEASE_KEYSTORE: ${{ secrets.ANDROID_RELEASE_KEYSTORE }}
+          ANDROID_SIGNING_PROPERTIES: ${{ secrets.ANDROID_SIGNING_PROPERTIES }}
+        run: |
+          echo $ANDROID_RELEASE_KEYSTORE | base64 --decode > config/release.keystore
+          echo $ANDROID_SIGNING_PROPERTIES | base64 --decode > signing.properties
+
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - uses: chkfung/android-version-actions@v1.1
+        with:
+          gradlePath: android/build.gradle.kts
+          versionCode: ${{ github.run_number }}
+
+      - name: Build Production release APK
+        run: ./gradlew assembleProductionRelease
+
+      - name: Deploy staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: '1:835959262689:android:cfc4c7eb6425a49c0896a0'
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
+          groups: nimble
+          file: android/build/outputs/apk/production/release/android-production-release.apk

--- a/.github/workflows/android_deploy_staging_build.yml
+++ b/.github/workflows/android_deploy_staging_build.yml
@@ -1,8 +1,5 @@
 name: Android - Deploy Staging build to Firebase
 
-# SECRETS needed:
-### FIREBASE_TOKEN
-
 on:
   push:
     branches:
@@ -20,7 +17,8 @@ jobs:
           distribution: 'adopt'
           java-version: '11'
 
-      - uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/android_deploy_staging_build.yml
+++ b/.github/workflows/android_deploy_staging_build.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Cache Gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches/modules-*
@@ -47,6 +47,6 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: '1:835959262689:android:d9b8f785d7bf477a0896a0'
-          token: ${{secrets.FIREBASE_TOKEN}}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: nimble
           file: android/build/outputs/apk/staging/debug/android-staging-debug.apk

--- a/.github/workflows/android_deploy_staging_build.yml
+++ b/.github/workflows/android_deploy_staging_build.yml
@@ -1,0 +1,52 @@
+name: Android - Deploy Staging build to Firebase
+
+# SECRETS needed:
+### FIREBASE_TOKEN
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  deploy_android_staging_to_firebase:
+    name: Deploy android staging to Firebase
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Java JDK
+        uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - uses: chkfung/android-version-actions@v1.1
+        with:
+          gradlePath: android/build.gradle.kts
+          versionCode: ${{ github.run_number }}
+
+      - name: Build Staging APK
+        run: ./gradlew assembleStagingDebug
+
+      - name: Deploy staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: '1:835959262689:android:d9b8f785d7bf477a0896a0'
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: nimble
+          file: android/build/outputs/apk/staging/debug/android-staging-debug.apk

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,9 @@ local.properties
 xcuserdata
 
 # Android
+# Google services
+google-services.json
+# Keystore
+config/release.keystore
 
 # iOS

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id(Plugins.ANDROID_APPLICATION)
     kotlin(Plugins.ANDROID)
+    id(Plugins.GOOGLE_SERVICES)
 }
 
 val keystoreProperties = rootDir.loadGradleProperties("signing.properties")
@@ -86,6 +87,11 @@ dependencies {
         implementation(MATERIAL)
         implementation(NAVIGATION)
         implementation(UI_TOOLING)
+    }
+
+    with(Dependencies.Firebase) {
+        implementation(platform(FIREBASE_BOM))
+        implementation(FIREBASE_ANALYTICS)
     }
 
     with(Dependencies.Log) {

--- a/android/src/staging/google-services.json
+++ b/android/src/staging/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "835959262689",
+    "project_id": "kmm-survey",
+    "storage_bucket": "kmm-survey.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:835959262689:android:d9b8f785d7bf477a0896a0",
+        "android_client_info": {
+          "package_name": "vn.luongvo.kmm.survey.android.staging"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "835959262689-9je6a0cec7ebnrp918q06hilt8e9ihac.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBHjDdrJXMSz4uNpxJ7eK-KLYepKDR5Lq8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "835959262689-9je6a0cec7ebnrp918q06hilt8e9ihac.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath(Dependencies.Gradle.GRADLE)
         classpath(Dependencies.Gradle.KOTLIN_GRADLE_PLUGIN)
+        classpath(Dependencies.Firebase.GOOGLE_SERVICES)
     }
 }
 

--- a/buildSrc/src/main/java/Configurations.kt
+++ b/buildSrc/src/main/java/Configurations.kt
@@ -23,6 +23,8 @@ object Plugins {
 
     const val KOTLIN_SERIALIZATION = "plugin.serialization"
     const val KOTLINX_SERIALIZATION = "kotlinx-serialization"
+
+    const val GOOGLE_SERVICES = "com.google.gms.google-services"
 }
 
 object XcodeConfiguration {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,6 +11,9 @@ object Versions {
     const val COMPOSE = "1.3.0"
     const val COMPOSE_NAVIGATION = "2.5.2"
 
+    const val FIREBASE_BOM = "31.1.0"
+
+    const val GOOGLE_SERVICES = "4.3.13"
     const val GRADLE = "7.0.4"
 
     const val JUNIT = "4.13.2"
@@ -37,6 +40,12 @@ object Dependencies {
         const val UI_TOOLING = "androidx.compose.ui:ui-tooling:${Versions.COMPOSE}"
         const val MATERIAL = "androidx.compose.material:material:${Versions.COMPOSE}"
         const val NAVIGATION = "androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION}"
+    }
+
+    object Firebase {
+        const val GOOGLE_SERVICES = "com.google.gms:google-services:${Versions.GOOGLE_SERVICES}"
+        const val FIREBASE_BOM = "com.google.firebase:firebase-bom:${Versions.FIREBASE_BOM}"
+        const val FIREBASE_ANALYTICS = "com.google.firebase:firebase-analytics-ktx"
     }
 
     object Log {


### PR DESCRIPTION
- Close #4

## What happened 👀

- Set up CD workflow to build and distribute Android staging build.
- Set up CD workflow to build and distribute Android production release build.

## Insight 📝

- Using `FIREBASE_TOKEN` to distribute apps to Firebase is deprecated. I followed this migration guide to use a service account instead https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration.

## Proof Of Work 📹

- Distribute staging build

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/16315358/204847690-538d4587-b80e-48f8-a96c-a94bf34d86f4.png">


- Distribute production build

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/16315358/204861131-a5e0111e-717e-4cd2-956a-df3f7388c0be.png">
