### PR TITLE
[#9] [Android] [UI] As a user, I can see the Splash screen

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/DimmedImageBackground.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/DimmedImageBackground.kt
@@ -12,11 +12,15 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color.Companion.Black
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import vn.luongvo.kmm.survey.android.ui.theme.Black20
 
 @Composable
-fun DimmedImageBackground(@DrawableRes imageRes: Int) {
+fun DimmedImageBackground(
+    @DrawableRes imageRes: Int,
+    blurRadius: Dp,
+    gradientAlpha: Float
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -29,7 +33,7 @@ fun DimmedImageBackground(@DrawableRes imageRes: Int) {
                 contentScale = ContentScale.FillWidth,
                 modifier = Modifier
                     .matchParentSize()
-                    .blur(radius = 25.dp)
+                    .blur(radius = blurRadius)
             )
             Box(
                 modifier = Modifier
@@ -37,8 +41,8 @@ fun DimmedImageBackground(@DrawableRes imageRes: Int) {
                     .background(
                         brush = Brush.verticalGradient(
                             colors = listOf(
-                                Black20,
-                                Black
+                                Black.copy(alpha = gradientAlpha * Black20.alpha),
+                                Black.copy(alpha = gradientAlpha)
                             )
                         )
                     )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/DimmedImageBackground.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/DimmedImageBackground.kt
@@ -21,32 +21,26 @@ fun DimmedImageBackground(
     blurRadius: Dp,
     gradientAlpha: Float
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Black)
-    ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Image(
-                painter = painterResource(id = imageRes),
-                contentDescription = null,
-                contentScale = ContentScale.FillWidth,
-                modifier = Modifier
-                    .matchParentSize()
-                    .blur(radius = blurRadius)
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                Black.copy(alpha = gradientAlpha * Black20.alpha),
-                                Black.copy(alpha = gradientAlpha)
-                            )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Image(
+            painter = painterResource(id = imageRes),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .matchParentSize()
+                .blur(radius = blurRadius)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Black.copy(alpha = gradientAlpha * Black20.alpha),
+                            Black.copy(alpha = gradientAlpha)
                         )
                     )
-            )
-        }
+                )
+        )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
@@ -5,12 +5,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.Black
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.tooling.preview.Preview
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.shapes
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
+import vn.luongvo.kmm.survey.android.ui.theme.BlackRussian
 
 @Composable
 fun PrimaryButton(
@@ -29,7 +29,7 @@ fun PrimaryButton(
     ) {
         Text(
             text = text,
-            color = Black,
+            color = BlackRussian,
             style = typography.button
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainActivity.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainActivity.kt
@@ -3,6 +3,7 @@ package vn.luongvo.kmm.survey.android.ui.screens
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import vn.luongvo.kmm.survey.android.ui.navigation.AppNavigation
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
@@ -10,6 +11,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         setContent {
             ComposeTheme {
                 AppNavigation()

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -25,9 +25,9 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.android.ui.theme.White50
 
-private const val FirstPhaseAnimDuration = 800
-private const val StayPhaseAnimDuration = 500
-private const val LastPhaseAnimDuration = 700
+private const val FirstPhaseDurationInMilliseconds = 800
+private const val StayPhaseDurationInMilliseconds = 500
+private const val LastPhaseDurationInMilliseconds = 700
 private const val BlurRadius = 25f
 private val LogoOffset = Offset(0f, -229f)
 
@@ -72,36 +72,31 @@ private fun LoginScreenContent(
     var alphaState by remember { mutableStateOf(initialAlphaState) }
     var blurState by remember { mutableStateOf(initialBlurState) }
 
+    val floatTweenSpec = tween<Float>(
+        durationMillis = LastPhaseDurationInMilliseconds,
+        delayMillis = StayPhaseDurationInMilliseconds
+    )
     val animateBlurState by animateFloatAsState(
         targetValue = blurState,
-        tween(
-            durationMillis = LastPhaseAnimDuration,
-            delayMillis = StayPhaseAnimDuration
-        )
+        floatTweenSpec
     )
     val animateAlphaState by animateFloatAsState(
         targetValue = alphaState,
-        tween(
-            durationMillis = LastPhaseAnimDuration,
-            delayMillis = StayPhaseAnimDuration
-        )
+        floatTweenSpec
+    )
+    val logoScaleAnimate by animateFloatAsState(
+        targetValue = logoScaleState,
+        floatTweenSpec
     )
     val logoOffsetAnimate by animateOffsetAsState(
         targetValue = logoOffsetState,
         tween(
-            durationMillis = LastPhaseAnimDuration,
-            delayMillis = StayPhaseAnimDuration
-        )
-    )
-    val logoScaleAnimate by animateFloatAsState(
-        targetValue = logoScaleState,
-        tween(
-            durationMillis = LastPhaseAnimDuration,
-            delayMillis = StayPhaseAnimDuration
+            durationMillis = LastPhaseDurationInMilliseconds,
+            delayMillis = StayPhaseDurationInMilliseconds
         )
     )
     LaunchedEffect(Unit) {
-        delay(FirstPhaseAnimDuration.toLong())
+        delay(FirstPhaseDurationInMilliseconds.toLong())
         logoVisible = true
         blurState = BlurRadius
         alphaState = 1f
@@ -127,8 +122,6 @@ private fun LoginScreenContent(
                 painter = painterResource(id = R.drawable.ic_nimble_logo),
                 contentDescription = null,
                 modifier = Modifier
-                    .align(Alignment.Center)
-                    .wrapContentHeight()
                     .padding(all = dimensions.paddingLarge)
                     .offset(logoOffsetAnimate.x.dp, logoOffsetAnimate.y.dp)
                     .scale(logoScaleAnimate)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -110,13 +110,11 @@ private fun LoginScreenContent(
     }
 
     Box {
-        Box(modifier = Modifier.fillMaxSize()) {
-            DimmedImageBackground(
-                imageRes = R.drawable.bg_login,
-                blurRadius = animateBlurState.dp,
-                gradientAlpha = animateAlphaState
-            )
-        }
+        DimmedImageBackground(
+            imageRes = R.drawable.bg_login,
+            blurRadius = animateBlurState.dp,
+            gradientAlpha = animateAlphaState
+        )
         AnimatedVisibility(
             visible = logoVisible,
             enter = fadeIn(),

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -28,6 +28,8 @@ import vn.luongvo.kmm.survey.android.ui.theme.White50
 private const val FirstPhaseAnimDuration = 800
 private const val StayPhaseAnimDuration = 500
 private const val LastPhaseAnimDuration = 700
+private const val BlurRadius = 25f
+private val LogoOffset = Offset(0f, -229f)
 
 @Composable
 fun LoginScreen(viewModel: LoginViewModel = getViewModel()) {
@@ -58,9 +60,18 @@ private fun LoginScreenContent(
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     onLogInClick: () -> Unit,
+    initialLogoVisible: Boolean = false,
+    initialLogoOffset: Offset = Offset(0f, 0f),
+    initialLogoScale: Float = 1.2f,
+    initialBlurState: Float = 0f,
+    initialAlphaState: Float = 0f
 ) {
-    var blurState by remember { mutableStateOf(0f) }
-    var alphaState by remember { mutableStateOf(0f) }
+    var logoVisible by remember { mutableStateOf(initialLogoVisible) }
+    var logoOffsetState by remember { mutableStateOf(initialLogoOffset) }
+    var logoScaleState by remember { mutableStateOf(initialLogoScale) }
+    var alphaState by remember { mutableStateOf(initialAlphaState) }
+    var blurState by remember { mutableStateOf(initialBlurState) }
+
     val animateBlurState by animateFloatAsState(
         targetValue = blurState,
         tween(
@@ -75,9 +86,6 @@ private fun LoginScreenContent(
             delayMillis = StayPhaseAnimDuration
         )
     )
-    var logoVisible by remember { mutableStateOf(false) }
-    var logoOffsetState by remember { mutableStateOf(Offset(0f, 0f)) }
-    var logoScaleState by remember { mutableStateOf(1.2f) }
     val logoOffsetAnimate by animateOffsetAsState(
         targetValue = logoOffsetState,
         tween(
@@ -95,10 +103,10 @@ private fun LoginScreenContent(
     LaunchedEffect(Unit) {
         delay(FirstPhaseAnimDuration.toLong())
         logoVisible = true
-        blurState = 25f
+        blurState = BlurRadius
         alphaState = 1f
-        logoOffsetState = Offset(0f, -229f)
-        logoScaleState = 1.0f
+        logoOffsetState = LogoOffset
+        logoScaleState = 1f
     }
 
     Box {
@@ -195,7 +203,12 @@ fun LoginScreenPreview() {
             password = "",
             onEmailChange = {},
             onPasswordChange = {},
-            onLogInClick = {}
+            onLogInClick = {},
+            initialLogoVisible = true,
+            initialLogoOffset = LogoOffset,
+            initialLogoScale = 1f,
+            initialBlurState = BlurRadius,
+            initialAlphaState = 1f
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/Color.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/Color.kt
@@ -1,9 +1,11 @@
 package vn.luongvo.kmm.survey.android.ui.theme
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.Black
 import androidx.compose.ui.graphics.Color.Companion.White
 
 internal val Black20 = Black.copy(alpha = 0.2f)
+internal val BlackRussian = Color(0xFF15151A)
 internal val White18 = White.copy(alpha = 0.18f)
 internal val White30 = White.copy(alpha = 0.3f)
 internal val White50 = White.copy(alpha = 0.5f)

--- a/android/src/main/res/values/colors.xml
+++ b/android/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="black_russian">#15151A</color>
+</resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,4 +1,8 @@
 <resources>
 
-    <style name="AppTheme" parent="android:Theme.Material.NoActionBar" />
+    <style name="AppTheme" parent="android:Theme.Material.NoActionBar">
+        <item name="android:windowBackground">@color/black_russian</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -67,7 +67,7 @@ complexity:
     threshold: 150
   LongMethod:
     active: true
-    threshold: 80
+    threshold: 60
   LongParameterList:
     active: true
     threshold: 8

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -67,10 +67,10 @@ complexity:
     threshold: 150
   LongMethod:
     active: true
-    threshold: 60
+    threshold: 80
   LongParameterList:
     active: true
-    threshold: 5
+    threshold: 8
     ignoreDefaultParameters: true
   MethodOverloading:
     active: false


### PR DESCRIPTION
- Close #9

## What happened 👀

- Implement the animation from the Splash screen to the Login screen.
- Optimize Login screen content for preview.
- Ensure the Splash screen stretches the full-screen edges.

## Insight 📝

- The animation logic is inspired by the previous implementation in Flutter https://github.com/luongvo/flutter-survey/pull/82 🤓 .
- We need to update some Detekt rules to adapt to the long method & more parameters Compose methods.
- To make the app strectch to full screen with transparent status bar & navigation bar:
  - Add `WindowCompat.setDecorFitsSystemWindows(window, false)` to MainActivity before `setContent`.
  - Update styles
    ```
            <item name="android:windowBackground">@color/black_russian</item>
            <item name="android:statusBarColor">@android:color/transparent</item>
            <item name="android:navigationBarColor">@android:color/transparent</item>
    ```

## Proof Of Work 📹



https://user-images.githubusercontent.com/16315358/208225427-6d47929f-92e9-4966-990f-4afe0d52d712.mp4




