### PR TITLE
[#12] [Backend] As a user, I can see my user profile on Home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@ A Nimble Survey KMM project.
 - [BuildKonfig](https://github.com/yshrsmz/BuildKonfig) embedding values from gradle file into BuildKonfig.
 - [Koin](https://github.com/InsertKoinIO/koin) as lightweight DI framework.
 - Networking
-  - [Ktor](https://ktor.io/docs/getting-started-ktor-client-multiplatform-mobile.html#ktor-dependencies) as networking
-    client.
-  - [kotlin-serialization](https://github.com/Kotlin/kotlinx.serialization) for data serialization.
-  - [jsonapi-kotlin](https://github.com/nimblehq/jsonapi-kotlin) for [JSON-API](https://jsonapi.org/) parsing.
+    - [Ktor](https://ktor.io/docs/getting-started-ktor-client-multiplatform-mobile.html#ktor-dependencies) as networking
+      client.
+    - [kotlin-serialization](https://github.com/Kotlin/kotlinx.serialization) for data serialization.
+    - [jsonapi-kotlin](https://github.com/nimblehq/jsonapi-kotlin) for [JSON-API](https://jsonapi.org/) parsing.
 - Logging with [Napier](https://github.com/AAkira/Napier).
 - Settings & Storage
-  - [multiplatform-settings](https://github.com/russhwolf/multiplatform-settings) for saving simple key-value data.
-    - Android: use [androidx-security-crypto](https://developer.android.com/jetpack/androidx/releases/security).
-    - iOS: use [KeychainSettings](https://github.com/russhwolf/multiplatform-settings#platform-constructors).
+    - [multiplatform-settings](https://github.com/russhwolf/multiplatform-settings) for saving simple key-value data.
+        - Android: use [androidx-security-crypto](https://developer.android.com/jetpack/androidx/releases/security).
+        - iOS: use [KeychainSettings](https://github.com/russhwolf/multiplatform-settings#platform-constructors).
 - Testing
-  - [mockative](https://github.com/mockative/mockative) for mockking shared module.
-  - [Kotest](https://github.com/kotest/kotest) for additional assertions, property testing and data driven testing.
-  - [Turbine](https://github.com/cashapp/turbine) as testing library for kotlinx.coroutines Flow.
+    - [mockative](https://github.com/mockative/mockative) for mockking shared module.
+    - [Kotest](https://github.com/kotest/kotest) for additional assertions, property testing and data driven testing.
+    - [Turbine](https://github.com/cashapp/turbine) as testing library for kotlinx.coroutines Flow.
+    - [kotlinx-resources](https://github.com/goncalossilva/kotlinx-resources) supports for reading resources in tests.
 - Code coverage by [Kover](https://github.com/Kotlin/kotlinx-kover).
 - Code analysis with [Lint](https://developer.android.com/studio/write/lint)
   and [Detekt](https://github.com/detekt/detekt).
@@ -37,9 +38,9 @@ A Nimble Survey KMM project.
 - [Koin](https://github.com/InsertKoinIO/koin).
 - Logging with [Timber](https://github.com/JakeWharton/timber).
 - Testing
-  - [MockK](https://github.com/mockk/mockk), [Kotest](https://github.com/kotest/kotest),
-    and [Turbine](https://github.com/cashapp/turbine).
-  - Jetpack Compose Instrument tests executed by [Robolectric](https://robolectric.org/).
+    - [MockK](https://github.com/mockk/mockk), [Kotest](https://github.com/kotest/kotest),
+      and [Turbine](https://github.com/cashapp/turbine).
+    - Jetpack Compose Instrument tests executed by [Robolectric](https://robolectric.org/).
 - Distributing to [Firebase](https://appdistribution.firebase.dev/i/11223fc5713bc511).
 
 ### iOS
@@ -57,12 +58,12 @@ Clone the repository
 ### Environments
 
 - Build types
-  - `debug`
-  - `release`
+    - `debug`
+    - `release`
 
 - Environment
-  - `staging`: local development and testing distribution.
-  - `production`: production deployment.
+    - `staging`: local development and testing distribution.
+    - `production`: production deployment.
 
 ## Linter and static code analysis
 
@@ -123,5 +124,7 @@ See [our other projects][community] or [hire our team][hire] to help build your 
 Want to join? [Check out our Jobs][jobs]!
 
 [community]: https://github.com/nimblehq
+
 [hire]: https://nimblehq.co/
+
 [jobs]: https://jobs.nimblehq.co/

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/MyApplication.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/MyApplication.kt
@@ -3,6 +3,7 @@ package vn.luongvo.kmm.survey.android
 import android.app.Application
 import org.koin.android.ext.koin.androidContext
 import timber.log.Timber
+import vn.luongvo.kmm.survey.android.di.homeModule
 import vn.luongvo.kmm.survey.android.di.loginModule
 import vn.luongvo.kmm.survey.di.initKoin
 
@@ -13,6 +14,7 @@ class MyApplication : Application() {
         initKoin {
             androidContext(applicationContext)
             modules(loginModule)
+            modules(homeModule)
         }
         setupLogging()
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/di/HomeModule.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/di/HomeModule.kt
@@ -1,0 +1,9 @@
+package vn.luongvo.kmm.survey.android.di
+
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.dsl.module
+import vn.luongvo.kmm.survey.android.ui.screens.home.HomeViewModel
+
+val homeModule = module {
+    viewModelOf(::HomeViewModel)
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -6,10 +6,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.tooling.preview.Preview
+import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
 @Composable
-fun HomeScreen() {
+fun HomeScreen(
+    viewModel: HomeViewModel = getViewModel()
+) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -1,0 +1,22 @@
+package vn.luongvo.kmm.survey.android.ui.screens.home
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.*
+import timber.log.Timber
+import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
+import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
+
+class HomeViewModel(
+    getUserProfileUseCase: GetUserProfileUseCase
+) : BaseViewModel() {
+
+    init {
+        getUserProfileUseCase()
+            .catch { e -> error = e }
+            .onEach {
+                // TODO Integrate getting user profile in https://github.com/luongvo/kmm-survey/issues/13
+                Timber.d(it.toString())
+            }
+            .launchIn(viewModelScope)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ koverMerged {
         "*.*Test*",                             // Test cases
         "*.*Mock",                              // mockative @Mock generated
         "*.test.*",                             // Test util package
+        "*.*\$\$serializer",                    // Kotlinx serializer
     )
     filters {
         classes {

--- a/buildSrc/src/main/java/Configurations.kt
+++ b/buildSrc/src/main/java/Configurations.kt
@@ -27,6 +27,7 @@ object Plugins {
     const val GOOGLE_SERVICES = "com.google.gms.google-services"
 
     const val KOTLIN_SERIALIZATION = "plugin.serialization"
+    const val KOTLINX_RESOURCES = "com.goncalossilva.resources"
     const val KOTLINX_SERIALIZATION = "kotlinx-serialization"
     const val KOVER = "kover"
     const val KOVER_PACKAGE = "org.jetbrains.kotlinx.kover"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,6 +32,7 @@ object Versions {
     const val KOTEST = "5.5.4"
     const val KOTLIN = "1.7.20"
     const val KOTLIN_COROUTINES = "1.6.4"
+    const val KOTLINX_RESOURCES = "0.2.4"
     const val KOVER = "0.6.1"
     const val KTOR = "2.1.1"
     const val KSP = "1.7.20-1.0.6"
@@ -114,6 +115,7 @@ object Dependencies {
         const val JUNIT = "junit:junit:${Versions.JUNIT}"
 
         const val KOTEST_ASSERTIONS = "io.kotest:kotest-assertions-core:${Versions.KOTEST}"
+        const val KOTLINX_RESOURCES = "com.goncalossilva:resources:${Versions.KOTLINX_RESOURCES}"
         const val MOCKATIVE = "io.mockative:mockative:${Versions.MOCKATIVE}"
         const val MOCKATIVE_PROCESSOR = "io.mockative:mockative-processor:${Versions.MOCKATIVE}"
         const val MOCKK = "io.mockk:mockk:${Versions.MOCKK}"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id(Plugins.KOTLINX_SERIALIZATION)
     id(Plugins.KOVER)
     id(Plugins.KSP).version(Versions.KSP)
+    id(Plugins.KOTLINX_RESOURCES).version(Versions.KOTLINX_RESOURCES)
 }
 
 kotlin {
@@ -57,6 +58,7 @@ kotlin {
                 with(Dependencies.Test) {
                     implementation(COROUTINES)
                     implementation(KOTEST_ASSERTIONS)
+                    implementation(KOTLINX_RESOURCES)
                     implementation(MOCKATIVE)
                     implementation(TURBINE)
                 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/UserRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/UserRemoteDataSource.kt
@@ -1,0 +1,18 @@
+package vn.luongvo.kmm.survey.data.remote.datasource
+
+import vn.luongvo.kmm.survey.data.remote.ApiClient
+import vn.luongvo.kmm.survey.data.remote.model.response.UserResponse
+
+interface UserRemoteDataSource {
+
+    suspend fun getUserProfile(): UserResponse
+}
+
+class UserRemoteDataSourceImpl(private val apiClient: ApiClient) : UserRemoteDataSource {
+
+    override suspend fun getUserProfile(): UserResponse {
+        return apiClient.get(
+            path = "/v1/me"
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/response/UserResponse.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/response/UserResponse.kt
@@ -1,0 +1,21 @@
+package vn.luongvo.kmm.survey.data.remote.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import vn.luongvo.kmm.survey.domain.model.User
+
+@Serializable
+data class UserResponse(
+    @SerialName("email")
+    val email: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("avatar_url")
+    val avatarUrl: String
+)
+
+fun UserResponse.toUser() = User(
+    email = email,
+    name = name,
+    avatarUrl = avatarUrl
+)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package vn.luongvo.kmm.survey.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.data.extensions.flowTransform
+import vn.luongvo.kmm.survey.data.remote.datasource.UserRemoteDataSource
+import vn.luongvo.kmm.survey.data.remote.model.response.toUser
+import vn.luongvo.kmm.survey.domain.model.User
+import vn.luongvo.kmm.survey.domain.repository.UserRepository
+
+class UserRepositoryImpl(
+    private val userRemoteDataSource: UserRemoteDataSource
+) : UserRepository {
+
+    override fun getUserProfile(): Flow<User> = flowTransform {
+        userRemoteDataSource
+            .getUserProfile()
+            .toUser()
+    }
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/RemoteModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/RemoteModule.kt
@@ -2,10 +2,10 @@ package vn.luongvo.kmm.survey.di.module
 
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
+import org.koin.dsl.bind
 import org.koin.dsl.module
 import vn.luongvo.kmm.survey.data.remote.ApiClient
-import vn.luongvo.kmm.survey.data.remote.datasource.AuthRemoteDataSource
-import vn.luongvo.kmm.survey.data.remote.datasource.AuthRemoteDataSourceImpl
+import vn.luongvo.kmm.survey.data.remote.datasource.*
 
 private const val UNAUTHORIZED_API_CLIENT = "UNAUTHORIZED_API_CLIENT"
 
@@ -13,4 +13,5 @@ val remoteModule = module {
     singleOf(::ApiClient)
     single(named(UNAUTHORIZED_API_CLIENT)) { ApiClient(get()) }
     single<AuthRemoteDataSource> { AuthRemoteDataSourceImpl(get(named(UNAUTHORIZED_API_CLIENT))) }
+    singleOf(::UserRemoteDataSourceImpl) bind UserRemoteDataSource::class
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/RepositoryModule.kt
@@ -4,8 +4,11 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import vn.luongvo.kmm.survey.data.repository.AuthRepositoryImpl
+import vn.luongvo.kmm.survey.data.repository.UserRepositoryImpl
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
+import vn.luongvo.kmm.survey.domain.repository.UserRepository
 
 val repositoryModule = module {
     singleOf(::AuthRepositoryImpl) bind AuthRepository::class
+    singleOf(::UserRepositoryImpl) bind UserRepository::class
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
@@ -8,4 +8,5 @@ import vn.luongvo.kmm.survey.domain.usecase.*
 val useCaseModule = module {
     singleOf(::LogInUseCaseImpl) bind LogInUseCase::class
     singleOf(::IsLoggedInUseCaseImpl) bind IsLoggedInUseCase::class
+    singleOf(::GetUserProfileUseCaseImpl) bind GetUserProfileUseCase::class
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/model/User.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/model/User.kt
@@ -1,0 +1,7 @@
+package vn.luongvo.kmm.survey.domain.model
+
+data class User(
+    val email: String,
+    val name: String,
+    val avatarUrl: String
+)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/UserRepository.kt
@@ -1,0 +1,9 @@
+package vn.luongvo.kmm.survey.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.domain.model.User
+
+interface UserRepository {
+
+    fun getUserProfile(): Flow<User>
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCase.kt
@@ -1,0 +1,17 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.domain.model.User
+import vn.luongvo.kmm.survey.domain.repository.UserRepository
+
+interface GetUserProfileUseCase {
+
+    operator fun invoke(): Flow<User>
+}
+
+class GetUserProfileUseCaseImpl(private val repository: UserRepository) : GetUserProfileUseCase {
+
+    override operator fun invoke(): Flow<User> {
+        return repository.getUserProfile()
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSourceTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSourceTest.kt
@@ -28,13 +28,13 @@ class TokenLocalDataSourceTest {
         dataSource.saveToken(token)
 
         verify(mockSettings)
-            .invocation { set("tokenType", "tokenType") }
+            .invocation { set("tokenType", "Bearer") }
             .wasInvoked(exactly = 1.time)
         verify(mockSettings)
-            .invocation { set("accessToken", "accessToken") }
+            .invocation { set("accessToken", "lbxD2K2BjbYtNzz8xjvh2FvSKx838KBCf79q773kq2c") }
             .wasInvoked(exactly = 1.time)
         verify(mockSettings)
-            .invocation { set("refreshToken", "refreshToken") }
+            .invocation { set("refreshToken", "3zJz2oW0njxlj_I3ghyUBF7ZfdQKYXd2n0ODlMkAjHc") }
             .wasInvoked(exactly = 1.time)
     }
 

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -46,7 +46,7 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `when calling logIn fails - it throws error`() = runTest {
+    fun `when calling logIn fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockAuthRemoteDataSource)
             .suspendFunction(mockAuthRemoteDataSource::logIn)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import vn.luongvo.kmm.survey.data.local.datasource.TokenLocalDataSource
 import vn.luongvo.kmm.survey.data.remote.datasource.AuthRemoteDataSource
-import vn.luongvo.kmm.survey.data.remote.model.response.toToken
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 import vn.luongvo.kmm.survey.test.Fake.token
 import vn.luongvo.kmm.survey.test.Fake.tokenResponse
@@ -41,7 +40,7 @@ class AuthRepositoryTest {
             .thenReturn(tokenResponse)
 
         repository.logIn("email", "password").test {
-            awaitItem() shouldBe tokenResponse.toToken()
+            awaitItem() shouldBe token
             awaitComplete()
         }
     }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
@@ -1,0 +1,55 @@
+package vn.luongvo.kmm.survey.data.repository
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.data.remote.datasource.UserRemoteDataSource
+import vn.luongvo.kmm.survey.domain.repository.UserRepository
+import vn.luongvo.kmm.survey.test.Fake.user
+import vn.luongvo.kmm.survey.test.Fake.userResponse
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class UserRepositoryTest {
+
+    @Mock
+    private val mockDataSource = mock(UserRemoteDataSource::class)
+
+    private lateinit var repository: UserRepository
+
+    @BeforeTest
+    fun setUp() {
+        repository = UserRepositoryImpl(
+            mockDataSource
+        )
+    }
+
+    @Test
+    fun `when calling getUserProfile successfully - it returns user`() = runTest {
+        given(mockDataSource)
+            .suspendFunction(mockDataSource::getUserProfile)
+            .whenInvoked()
+            .thenReturn(userResponse)
+
+        repository.getUserProfile().test {
+            awaitItem() shouldBe user
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling getUserProfile fails - it throws error`() = runTest {
+        val throwable = Throwable()
+        given(mockDataSource)
+            .suspendFunction(mockDataSource::getUserProfile)
+            .whenInvoked()
+            .thenThrow(throwable)
+
+        repository.getUserProfile().test {
+            awaitError() shouldBe throwable
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
@@ -41,7 +41,7 @@ class UserRepositoryTest {
     }
 
     @Test
-    fun `when calling getUserProfile fails - it throws error`() = runTest {
+    fun `when calling getUserProfile fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockDataSource)
             .suspendFunction(mockDataSource::getUserProfile)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetUserProfileUseCaseTest {
     }
 
     @Test
-    fun `when calling getUserProfile fails - it throws error`() = runTest {
+    fun `when calling getUserProfile fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockRepository)
             .function(mockRepository::getUserProfile)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCaseTest.kt
@@ -1,0 +1,55 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.domain.repository.UserRepository
+import vn.luongvo.kmm.survey.test.Fake.user
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class GetUserProfileUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(UserRepository::class)
+
+    private lateinit var useCase: GetUserProfileUseCase
+
+    @BeforeTest
+    fun setUp() {
+        useCase = GetUserProfileUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when calling getUserProfile successfully - it returns user`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::getUserProfile)
+            .whenInvoked()
+            .thenReturn(flowOf(user))
+
+        useCase().test {
+            awaitItem() shouldBe user
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling getUserProfile fails - it throws error`() = runTest {
+        val throwable = Throwable()
+        given(mockRepository)
+            .function(mockRepository::getUserProfile)
+            .whenInvoked()
+            .thenReturn(
+                flow { throw throwable }
+            )
+
+        useCase().test {
+            awaitError() shouldBe throwable
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/IsLoggedInUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/IsLoggedInUseCaseTest.kt
@@ -37,7 +37,7 @@ class IsLoggedInUseCaseTest {
     }
 
     @Test
-    fun `when calling isLoggedIn fails - it throws error`() = runTest {
+    fun `when calling isLoggedIn fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockRepository)
             .invocation { mockRepository.isLoggedIn }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogInUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogInUseCaseTest.kt
@@ -44,7 +44,7 @@ class LogInUseCaseTest {
     }
 
     @Test
-    fun `when calling logIn fails - it throws error`() = runTest {
+    fun `when calling logIn fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockRepository)
             .function(mockRepository::logIn)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/test/Fake.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/test/Fake.kt
@@ -2,8 +2,7 @@ package vn.luongvo.kmm.survey.test
 
 import co.nimblehq.jsonapi.model.JsonApiError
 import co.nimblehq.jsonapi.model.JsonApiException
-import vn.luongvo.kmm.survey.data.remote.model.response.TokenResponse
-import vn.luongvo.kmm.survey.data.remote.model.response.toToken
+import vn.luongvo.kmm.survey.data.remote.model.response.*
 
 object Fake {
 
@@ -23,4 +22,12 @@ object Fake {
     )
 
     val token = tokenResponse.toToken()
+
+    val userResponse = UserResponse(
+        email = "luong@nimblehq.co",
+        name = "Luong",
+        avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+    )
+
+    val user = userResponse.toUser()
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/test/Fake.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/test/Fake.kt
@@ -1,10 +1,34 @@
 package vn.luongvo.kmm.survey.test
 
+import co.nimblehq.jsonapi.json.JsonApi
 import co.nimblehq.jsonapi.model.JsonApiError
 import co.nimblehq.jsonapi.model.JsonApiException
+import com.goncalossilva.resources.Resource
+import kotlinx.serialization.json.Json
 import vn.luongvo.kmm.survey.data.remote.model.response.*
 
 object Fake {
+
+    private val json = Json {
+        prettyPrint = true
+        isLenient = true
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    }
+
+    private inline fun <reified T> decodeFromJsonApiString(resource: Resource): T {
+        return JsonApi(json).decodeFromJsonApiString(resource.readText())
+    }
+
+    val tokenResponse: TokenResponse =
+        decodeFromJsonApiString(Resource("src/commonTest/resources/oauth_login.json"))
+
+    val token = tokenResponse.toToken()
+
+    val userResponse: UserResponse =
+        decodeFromJsonApiString(Resource("src/commonTest/resources/user.json"))
+
+    val user = userResponse.toUser()
 
     val jsonApiException = JsonApiException(
         errors = listOf(
@@ -14,20 +38,4 @@ object Fake {
             )
         )
     )
-
-    val tokenResponse = TokenResponse(
-        tokenType = "tokenType",
-        accessToken = "accessToken",
-        refreshToken = "refreshToken"
-    )
-
-    val token = tokenResponse.toToken()
-
-    val userResponse = UserResponse(
-        email = "luong@nimblehq.co",
-        name = "Luong",
-        avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
-    )
-
-    val user = userResponse.toUser()
 }

--- a/shared/src/commonTest/resources/oauth_login.json
+++ b/shared/src/commonTest/resources/oauth_login.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "id": "10",
+    "type": "token",
+    "attributes": {
+      "access_token": "lbxD2K2BjbYtNzz8xjvh2FvSKx838KBCf79q773kq2c",
+      "token_type": "Bearer",
+      "expires_in": 7200,
+      "refresh_token": "3zJz2oW0njxlj_I3ghyUBF7ZfdQKYXd2n0ODlMkAjHc",
+      "created_at": 1597169495
+    }
+  }
+}

--- a/shared/src/commonTest/resources/user.json
+++ b/shared/src/commonTest/resources/user.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "31",
+    "type": "user",
+    "attributes": {
+      "email": "luong@nimblehq.co",
+      "name": "Luong",
+      "avatar_url": "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+    }
+  }
+}


### PR DESCRIPTION
- Close #12

## What happened 👀

- Implement backend components for user profile API.
- Add sample request in `HomeViewModel`.

## Insight 📝

- Optimize: prepare responses from raw JSON data resources instead https://github.com/goncalossilva/kotlinx-resources to verify JSON:API `Response` models.

## Proof Of Work 📹

```
2022-12-26 23:41:27.394 19370-19370/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeRequestLog: REQUEST: https://survey-api.nimblehq.co/api/v1/me
    METHOD: HttpMethod(value=GET)
    COMMON HEADERS
    -> Accept: application/json
    -> Accept-Charset: UTF-8
    -> Authorization: Bearer aVSmtnwWmbz23javXIWa2xUVcfxgGbZ1kdlk0algwG4
    -> Content-Type: application/json
    CONTENT HEADERS
    -> Content-Length: 0
    BODY Content-Type: null
    BODY START
    
    BODY END
2022-12-26 23:41:28.780 19370-19419/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeResponseLog: RESPONSE: 200 OK
    METHOD: HttpMethod(value=GET)
    FROM: https://survey-api.nimblehq.co/api/v1/me
    COMMON HEADERS
    -> alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
    -> cache-control: max-age=0, private, must-revalidate
    -> cf-cache-status: DYNAMIC
    -> cf-ray: 77fb439748788983-SIN
    -> connection: keep-alive
    -> content-type: application/json; charset=utf-8
    -> date: Mon, 26 Dec 2022 16:41:27 GMT
    -> etag: W/"2866f30fe84de38bfcbfef28b8baa28d"
    -> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
    -> referrer-policy: strict-origin-when-cross-origin
    -> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=KZkb%2BqBku36rlEuH0i4%2FZOzfnDhY3KYdBIZznKv1JJLniKMYtUQieDIo8UdVBoWJ0Qr442bdIAk0vf3UXXGyX64zWuLA2dZkkJIGO1FpLfJq18IW6JhKg9zO1bqEWaRcsQQz8bNtv9zJD9%2Bd601MByl%2FQ1yG"}],"group":"cf-nel","max_age":604800}
    -> server: cloudflare
    -> strict-transport-security: max-age=31536000; includeSubDomains
    -> transfer-encoding: chunked
    -> vary: Accept-Encoding, Origin
    -> via: 1.1 vegur
    -> x-android-received-millis: 1672072888724
    -> x-android-response-source: NETWORK 200
    -> x-android-selected-protocol: http/1.1
    -> x-android-sent-millis: 1672072887730
    -> x-content-type-options: nosniff
    -> x-download-options: noopen
    -> x-frame-options: SAMEORIGIN
    -> x-permitted-cross-domain-policies: none
    -> x-request-id: 3d67912a-905c-4769-a6b4-60d3afe6463f
    -> x-runtime: 0.040405
    -> x-xss-protection: 1; mode=block
    BODY Content-Type: application/json; charset=utf-8
    BODY START
    {"data":{"id":"31","type":"user","attributes":{"email":"luong@nimblehq.co","name":"Luong","avatar_url":"https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"}}}
    BODY END
2022-12-26 23:41:28.843 19370-19370/vn.luongvo.kmm.survey.android.staging D/HomeViewModel: User(email=luong@nimblehq.co, name=Luong, avatarUrl=https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23)
```
