### PR TITLE
[#10] [Backend] As a user, I can continue to use the app (refresh token) when it expired

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -7,10 +7,22 @@ import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
 import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
 
 class HomeViewModel(
-    getUserProfileUseCase: GetUserProfileUseCase
+    getUserProfileUseCase: GetUserProfileUseCase,
+//    tokenLocalDataSource: TokenLocalDataSource
 ) : BaseViewModel() {
 
     init {
+        // TODO test code for POW, will remove it in the next PR
+//        tokenLocalDataSource.run {
+//            saveToken(
+//                Token(
+//                    tokenType,
+//                    "invalid_access_token",
+//                    refreshToken
+//                )
+//            )
+//        }
+
         getUserProfileUseCase()
             .catch { e -> error = e }
             .onEach {

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -33,9 +33,9 @@ const val LoginEmailField = "LoginEmailField"
 const val LoginPasswordField = "LoginPasswordField"
 const val LoginButton = "LoginButton"
 
-private const val FirstPhaseDurationInMilliseconds = 800
-private const val StayPhaseDurationInMilliseconds = 500
-private const val LastPhaseDurationInMilliseconds = 700
+const val FirstPhaseDurationInMilliseconds = 800
+const val StayPhaseDurationInMilliseconds = 500
+const val LastPhaseDurationInMilliseconds = 700
 private const val BlurRadius = 25f
 private val LogoOffset = Offset(0f, -229f)
 

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
@@ -19,6 +19,9 @@ import vn.luongvo.kmm.survey.domain.exceptions.ApiException
 import vn.luongvo.kmm.survey.domain.usecase.IsLoggedInUseCase
 import vn.luongvo.kmm.survey.domain.usecase.LogInUseCase
 
+private const val LoginAnimationDurationInMilliseconds =
+    FirstPhaseDurationInMilliseconds + StayPhaseDurationInMilliseconds + LastPhaseDurationInMilliseconds
+
 @RunWith(AndroidJUnit4::class)
 class LoginScreenTest {
 
@@ -94,7 +97,7 @@ class LoginScreenTest {
         onNodeWithContentDescription(LoginButton).performClick()
         waitForIdle()
 
-        onNodeWithText(expectedError.message ?: "").assertIsDisplayed()
+        onNodeWithText(expectedError.message.orEmpty()).assertIsDisplayed()
         onNodeWithText(context.getString(R.string.generic_ok)).assertIsDisplayed().performClick()
     }
 
@@ -109,6 +112,6 @@ class LoginScreenTest {
     }
 
     private fun ComposeContentTestRule.waitForAnimationEnd() {
-        mainClock.advanceTimeBy(800 + 500 + 700)
+        mainClock.advanceTimeBy(LoginAnimationDurationInMilliseconds.toLong())
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
@@ -60,7 +60,7 @@ class ApiClient(
                         }
 
                         refreshTokens {
-                            val token = refreshTokenUseCase(refreshToken = oldTokens?.refreshToken ?: "")
+                            val token = refreshTokenUseCase(refreshToken = oldTokens?.refreshToken.orEmpty())
                                 .last()
                             BearerTokens(token.accessToken, token.refreshToken)
                         }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
@@ -14,13 +14,17 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.flow.last
 import kotlinx.serialization.json.Json
+import vn.luongvo.kmm.survey.BuildKonfig
 import vn.luongvo.kmm.survey.data.extensions.path
 import vn.luongvo.kmm.survey.data.local.datasource.TokenLocalDataSource
+import vn.luongvo.kmm.survey.domain.usecase.RefreshTokenUseCase
 
 class ApiClient(
     engine: HttpClientEngine,
-    tokenLocalDataSource: TokenLocalDataSource? = null
+    tokenLocalDataSource: TokenLocalDataSource? = null,
+    refreshTokenUseCase: RefreshTokenUseCase? = null
 ) {
 
     val httpClient: HttpClient
@@ -48,11 +52,21 @@ class ApiClient(
                 json(json)
             }
 
-            tokenLocalDataSource?.let {
+            if (tokenLocalDataSource != null && refreshTokenUseCase != null) {
                 install(Auth) {
                     bearer {
                         loadTokens {
                             BearerTokens(tokenLocalDataSource.accessToken, tokenLocalDataSource.refreshToken)
+                        }
+
+                        refreshTokens {
+                            val token = refreshTokenUseCase(refreshToken = oldTokens?.refreshToken ?: "")
+                                .last()
+                            BearerTokens(token.accessToken, token.refreshToken)
+                        }
+
+                        sendWithoutRequest { request ->
+                            request.url.host == Url(BuildKonfig.BASE_URL).host
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/AuthRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/AuthRemoteDataSource.kt
@@ -2,16 +2,26 @@ package vn.luongvo.kmm.survey.data.remote.datasource
 
 import vn.luongvo.kmm.survey.data.remote.ApiClient
 import vn.luongvo.kmm.survey.data.remote.model.request.LoginRequestBody
+import vn.luongvo.kmm.survey.data.remote.model.request.RefreshTokenRequestBody
 import vn.luongvo.kmm.survey.data.remote.model.response.TokenResponse
 
 interface AuthRemoteDataSource {
 
     suspend fun logIn(body: LoginRequestBody): TokenResponse
+
+    suspend fun refreshToken(body: RefreshTokenRequestBody): TokenResponse
 }
 
 class AuthRemoteDataSourceImpl(private val apiClient: ApiClient) : AuthRemoteDataSource {
 
     override suspend fun logIn(body: LoginRequestBody): TokenResponse {
+        return apiClient.post(
+            path = "/v1/oauth/token",
+            requestBody = body
+        )
+    }
+
+    override suspend fun refreshToken(body: RefreshTokenRequestBody): TokenResponse {
         return apiClient.post(
             path = "/v1/oauth/token",
             requestBody = body

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/request/RefreshTokenRequestBody.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/request/RefreshTokenRequestBody.kt
@@ -1,0 +1,19 @@
+package vn.luongvo.kmm.survey.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import vn.luongvo.kmm.survey.BuildKonfig
+
+private const val GRANT_TYPE_REFRESH_TOKEN = "refresh_token"
+
+@Serializable
+data class RefreshTokenRequestBody(
+    @SerialName("grant_type")
+    val grantType: String = GRANT_TYPE_REFRESH_TOKEN,
+    @SerialName("refresh_token")
+    val refreshToken: String,
+    @SerialName("client_id")
+    val clientId: String = BuildKonfig.CLIENT_ID,
+    @SerialName("client_secret")
+    val clientSecret: String = BuildKonfig.CLIENT_SECRET,
+)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
@@ -6,6 +6,7 @@ import vn.luongvo.kmm.survey.data.extensions.flowTransform
 import vn.luongvo.kmm.survey.data.local.datasource.TokenLocalDataSource
 import vn.luongvo.kmm.survey.data.remote.datasource.AuthRemoteDataSource
 import vn.luongvo.kmm.survey.data.remote.model.request.LoginRequestBody
+import vn.luongvo.kmm.survey.data.remote.model.request.RefreshTokenRequestBody
 import vn.luongvo.kmm.survey.data.remote.model.response.toToken
 import vn.luongvo.kmm.survey.domain.model.Token
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
@@ -18,6 +19,12 @@ class AuthRepositoryImpl(
     override fun logIn(email: String, password: String): Flow<Token> = flowTransform {
         authRemoteDataSource
             .logIn(LoginRequestBody(email = email, password = password))
+            .toToken()
+    }
+
+    override fun refreshToken(refreshToken: String): Flow<Token> = flowTransform {
+        authRemoteDataSource
+            .refreshToken(RefreshTokenRequestBody(refreshToken = refreshToken))
             .toToken()
     }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
@@ -9,4 +9,5 @@ val useCaseModule = module {
     singleOf(::LogInUseCaseImpl) bind LogInUseCase::class
     singleOf(::IsLoggedInUseCaseImpl) bind IsLoggedInUseCase::class
     singleOf(::GetUserProfileUseCaseImpl) bind GetUserProfileUseCase::class
+    singleOf(::RefreshTokenUseCaseImpl) bind RefreshTokenUseCase::class
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
@@ -7,6 +7,8 @@ interface AuthRepository {
 
     fun logIn(email: String, password: String): Flow<Token>
 
+    fun refreshToken(refreshToken: String): Flow<Token>
+
     fun saveToken(token: Token)
 
     val isLoggedIn: Flow<Boolean>

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCase.kt
@@ -1,6 +1,7 @@
 package vn.luongvo.kmm.survey.domain.usecase
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
 import vn.luongvo.kmm.survey.domain.model.Token
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 
@@ -13,5 +14,6 @@ class RefreshTokenUseCaseImpl(private val repository: AuthRepository) : RefreshT
 
     override operator fun invoke(refreshToken: String): Flow<Token> {
         return repository.refreshToken(refreshToken)
+            .onEach { token -> repository.saveToken(token) }
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCase.kt
@@ -1,0 +1,17 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.domain.model.Token
+import vn.luongvo.kmm.survey.domain.repository.AuthRepository
+
+interface RefreshTokenUseCase {
+
+    operator fun invoke(refreshToken: String): Flow<Token>
+}
+
+class RefreshTokenUseCaseImpl(private val repository: AuthRepository) : RefreshTokenUseCase {
+
+    override operator fun invoke(refreshToken: String): Flow<Token> {
+        return repository.refreshToken(refreshToken)
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -72,7 +72,7 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `when calling refreshToken fails - it throws error`() = runTest {
+    fun `when calling refreshToken fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockAuthRemoteDataSource)
             .suspendFunction(mockAuthRemoteDataSource::refreshToken)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -59,6 +59,32 @@ class AuthRepositoryTest {
     }
 
     @Test
+    fun `when calling refreshToken successfully - it returns token`() = runTest {
+        given(mockAuthRemoteDataSource)
+            .suspendFunction(mockAuthRemoteDataSource::refreshToken)
+            .whenInvokedWith(any())
+            .thenReturn(tokenResponse)
+
+        repository.refreshToken("refreshToken").test {
+            awaitItem() shouldBe token
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling refreshToken fails - it throws error`() = runTest {
+        val throwable = Throwable()
+        given(mockAuthRemoteDataSource)
+            .suspendFunction(mockAuthRemoteDataSource::refreshToken)
+            .whenInvokedWith(any())
+            .thenThrow(throwable)
+
+        repository.refreshToken("refreshToken").test {
+            awaitError() shouldBe throwable
+        }
+    }
+
+    @Test
     fun `when saving token - it executes the local data source`() = runTest {
         repository.saveToken(token)
         verify(mockTokenLocalDataSource)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCaseTest.kt
@@ -1,0 +1,65 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.domain.repository.AuthRepository
+import vn.luongvo.kmm.survey.test.Fake.token
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class RefreshTokenUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(AuthRepository::class)
+
+    private lateinit var useCase: RefreshTokenUseCase
+
+    @BeforeTest
+    fun setUp() {
+        useCase = RefreshTokenUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when calling refreshToken successfully - it returns token`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::refreshToken)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(token))
+
+        useCase("refreshToken").test {
+            awaitItem() shouldBe token
+            awaitComplete()
+        }
+
+        verify(mockRepository)
+            .function(mockRepository::saveToken)
+            .with(eq(token))
+            .wasInvoked(exactly = 1.time)
+    }
+
+    @Test
+    fun `when calling refreshToken fails - it throws error`() = runTest {
+        val throwable = Throwable()
+        given(mockRepository)
+            .function(mockRepository::refreshToken)
+            .whenInvokedWith(any())
+            .thenReturn(
+                flow { throw throwable }
+            )
+
+        useCase("refreshToken").test {
+            awaitError() shouldBe throwable
+        }
+
+        verify(mockRepository)
+            .function(mockRepository::saveToken)
+            .with(any())
+            .wasNotInvoked()
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCaseTest.kt
@@ -44,7 +44,7 @@ class RefreshTokenUseCaseTest {
     }
 
     @Test
-    fun `when calling refreshToken fails - it throws error`() = runTest {
+    fun `when calling refreshToken fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockRepository)
             .function(mockRepository::refreshToken)

--- a/shared/src/iosMain/kotlin/vn/luongvo/kmm/survey/di/module/PlatformModule.kt
+++ b/shared/src/iosMain/kotlin/vn/luongvo/kmm/survey/di/module/PlatformModule.kt
@@ -10,7 +10,7 @@ import platform.Foundation.NSBundle
 actual fun platformModule(): Module = module {
     single { Darwin.create() }
 
-    val serviceName = NSBundle.mainBundle().bundleIdentifier ?: ""
+    val serviceName = NSBundle.mainBundle().bundleIdentifier.orEmpty()
     single<Settings> {
         KeychainSettings(serviceName)
     }


### PR DESCRIPTION
- Close #10

## What happened 👀

- Implement backend components for refresh token API.
- Configure Ktor bearer authentication mechanism https://ktor.io/docs/bearer-client.html#configure for re-authentication.
- Save the new token after refreshing.

## Insight 📝

N/A

## Proof Of Work 📹

```
2022-12-27 01:20:06.465 24254-24254/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeRequestLog: REQUEST: https://survey-api.nimblehq.co/api/v1/me
    METHOD: HttpMethod(value=GET)
    COMMON HEADERS
    -> Accept: application/json
    -> Accept-Charset: UTF-8
    -> Authorization: Bearer invalid_access_token
    -> Content-Type: application/json
    CONTENT HEADERS
    -> Content-Length: 0
    BODY Content-Type: null
    BODY START
    
    BODY END
2022-12-27 01:20:07.579 24254-24296/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeResponseLog: RESPONSE: 401 Unauthorized
    METHOD: HttpMethod(value=GET)
    FROM: https://survey-api.nimblehq.co/api/v1/me
    COMMON HEADERS
    -> alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
    -> cache-control: private, no-store
    -> cf-cache-status: DYNAMIC
    -> cf-ray: 77fbd4187e2391cc-SIN
    -> connection: keep-alive
    -> content-type: application/json; charset=utf-8
    -> date: Mon, 26 Dec 2022 18:20:06 GMT
    -> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
    -> pragma: no-cache
    -> referrer-policy: strict-origin-when-cross-origin
    -> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=t6Pk%2F4%2BPBL7ch7TYdmjA8mP2OV5N08cHIjr6HbEb9jzV75EYh0SsuhbwKIPfhz1YZNObG%2FM7lX3rD0CY6B4pNZsnqf6MGSgKxbXjshtVetmwPnAL%2Fl2QqOUqpwJSGgb5TaCKzzI%2F6JJwgM4YGbx5BE4dnplT"}],"group":"cf-nel","max_age":604800}
    -> server: cloudflare
    -> strict-transport-security: max-age=31536000; includeSubDomains
    -> transfer-encoding: chunked
    -> vary: Accept-Encoding, Origin
    -> via: 1.1 vegur
    -> www-authenticate: Bearer realm="Doorkeeper", error="invalid_token", error_description="The access token is invalid"
    -> x-android-received-millis: 1672078807514
    -> x-android-response-source: NETWORK 401
    -> x-android-selected-protocol: http/1.1
    -> x-android-sent-millis: 1672078806610
    -> x-content-type-options: nosniff
    -> x-download-options: noopen
    -> x-frame-options: SAMEORIGIN
    -> x-permitted-cross-domain-policies: none
    -> x-request-id: 34b9f5fd-7579-47ca-94f5-f571682061ed
    -> x-runtime: 0.005729
    -> x-xss-protection: 1; mode=block
    BODY Content-Type: application/json; charset=utf-8
    BODY START
    {"errors":[{"detail":"The access token is invalid","code":"invalid_token"}]}
    BODY END
2022-12-27 01:20:07.619 24254-24254/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeRequestLog: REQUEST: https://survey-api.nimblehq.co/api/v1/oauth/token
    METHOD: HttpMethod(value=POST)
    COMMON HEADERS
    -> Accept: application/json
    -> Accept-Charset: UTF-8
    CONTENT HEADERS
    -> Content-Length: 237
    -> Content-Type: application/json
    BODY Content-Type: application/json
    BODY START
    {
        "grant_type": "refresh_token",
        "refresh_token": "ct9dG9UKyUJVUkhzFJzjb811-8t3R5AjPUL3IyjCXB4",
        "client_id": "6GbE8dhoz519l2N_F99StqoOs6Tcmm1rXgda4q__rIw",
        "client_secret": "_ayfIm7BeUAhx2W1OUqi20fwO3uNxfo1QstyKlFCgHw"
    }
    BODY END
2022-12-27 01:20:08.051 24254-24305/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeResponseLog: RESPONSE: 200 OK
    METHOD: HttpMethod(value=POST)
    FROM: https://survey-api.nimblehq.co/api/v1/oauth/token
    COMMON HEADERS
    -> alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
    -> cache-control: private, no-store
    -> cf-cache-status: DYNAMIC
    -> cf-ray: 77fbd41e2c6591cc-SIN
    -> connection: keep-alive
    -> content-type: application/json; charset=utf-8
    -> date: Mon, 26 Dec 2022 18:20:07 GMT
    -> etag: W/"9078980d3c1f05328a42cc813621c865"
    -> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
    -> pragma: no-cache
    -> referrer-policy: strict-origin-when-cross-origin
    -> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=aTMj2jNHj3reX9kNloelHbw5XxLTh3%2FIVaIOgATK6dNB2GaT4dJz4zcJ2TipPUAG1hRcw3fv3s3ojJBnorepi%2B6EgR3UbVQAVubjWfMbkdUdHW6xsWYZ4sPut7M6b1aqglrWSRWq4PFdWT%2Fofmn0R%2Fgl6zZ%2F"}],"group":"cf-nel","max_age":604800}
    -> server: cloudflare
    -> strict-transport-security: max-age=31536000; includeSubDomains
    -> transfer-encoding: chunked
    -> vary: Accept-Encoding, Origin
    -> via: 1.1 vegur
    -> x-android-received-millis: 1672078808023
    -> x-android-response-source: NETWORK 200
    -> x-android-selected-protocol: http/1.1
    -> x-android-sent-millis: 1672078807626
    -> x-content-type-options: nosniff
    -> x-download-options: noopen
    -> x-frame-options: SAMEORIGIN
    -> x-permitted-cross-domain-policies: none
    -> x-request-id: 4848954d-4a64-46fb-bc92-d3300b0bd6c1
    -> x-runtime: 0.020815
    -> x-xss-protection: 1; mode=block
    BODY Content-Type: application/json; charset=utf-8
    BODY START
    {"data":{"id":"14388","type":"token","attributes":{"access_token":"oK5r3Yn8ZXtI81K7Te_CnkYK7j65iPOh_dvdKw4FIHY","token_type":"Bearer","expires_in":7200,"refresh_token":"Pu-FQHPYPyAlI8cfKOzrbamtAIH1mntiIgo3u-WvOxY","created_at":1672078806}}}
    BODY END
2022-12-27 01:20:08.121 24254-24254/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeRequestLog: REQUEST: https://survey-api.nimblehq.co/api/v1/me
    METHOD: HttpMethod(value=GET)
    COMMON HEADERS
    -> Accept: application/json
    -> Accept-Charset: UTF-8
    -> Authorization: Bearer oK5r3Yn8ZXtI81K7Te_CnkYK7j65iPOh_dvdKw4FIHY
    -> Content-Type: application/json
    CONTENT HEADERS
    -> Content-Length: 0
    BODY Content-Type: null
    BODY START
    
    BODY END
2022-12-27 01:20:08.481 24254-24296/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeResponseLog: RESPONSE: 200 OK
    METHOD: HttpMethod(value=GET)
    FROM: https://survey-api.nimblehq.co/api/v1/me
    COMMON HEADERS
    -> alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
    -> cache-control: max-age=0, private, must-revalidate
    -> cf-cache-status: DYNAMIC
    -> cf-ray: 77fbd4215fff91cc-SIN
    -> connection: keep-alive
    -> content-type: application/json; charset=utf-8
    -> date: Mon, 26 Dec 2022 18:20:07 GMT
    -> etag: W/"5a5e560415e79da2bf7ad0f9a9faa99b"
    -> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
    -> referrer-policy: strict-origin-when-cross-origin
    -> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Lz0wSAdyPTmobjMYywgqvaH7Q73NGE9MoLtwTXdnO%2F1dYn9pMhPJyPlOE6FIfKTiDuEYJV5LNjoOwWTbdpeB7blsIJJ8zopMwSZdT99hYjSnFXv0unAyrej2w3zcCNusDi6VA6ZzaUk%2BP55JPKOLLZdhvw%2Fw"}],"group":"cf-nel","max_age":604800}
    -> server: cloudflare
    -> strict-transport-security: max-age=31536000; includeSubDomains
    -> transfer-encoding: chunked
    -> vary: Accept-Encoding, Origin
    -> via: 1.1 vegur
    -> x-android-received-millis: 1672078808457
    -> x-android-response-source: NETWORK 200
    -> x-android-selected-protocol: http/1.1
    -> x-android-sent-millis: 1672078808126
    -> x-content-type-options: nosniff
    -> x-download-options: noopen
    -> x-frame-options: SAMEORIGIN
    -> x-permitted-cross-domain-policies: none
    -> x-request-id: d0eed1e4-c08e-4997-b09e-c1d88e880b3a
    -> x-runtime: 0.016060
    -> x-xss-protection: 1; mode=block
    BODY Content-Type: application/json; charset=utf-8
    BODY START
    {"data":{"id":"31","type":"user","attributes":{"email":"luong@nimblehq.co","name":"Luong","avatar_url":"https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"}}}
    BODY END
2022-12-27 01:20:08.494 24254-24254/vn.luongvo.kmm.survey.android.staging D/HomeViewModel: User(email=luong@nimblehq.co, name=Luong, avatarUrl=https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23)
```
