### PR TITLE
[#11] [Android] [UI] As a user, I can see the Home screen header

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
         implementation(MATERIAL)
         implementation(NAVIGATION)
         implementation(UI_TOOLING)
+        implementation(COIL_COMPOSE)
     }
     with(Dependencies.Firebase) {
         implementation(platform(FIREBASE_BOM))

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -1,28 +1,39 @@
 package vn.luongvo.kmm.survey.android.ui.screens.home
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import org.koin.androidx.compose.getViewModel
+import vn.luongvo.kmm.survey.android.ui.screens.home.views.HomeHeader
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel = getViewModel()
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize()
+    HomeScreenContent()
+}
+
+@Composable
+private fun HomeScreenContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            // TODO demo background, integrate in https://github.com/luongvo/kmm-survey/issues/16
+            .background(Color(0xFF8E9398))
     ) {
-        Text(
-            text = "Home",
-            color = White,
-            modifier = Modifier
-                .fillMaxSize()
-                .wrapContentSize()
-        )
+        Column(
+            modifier = Modifier.statusBarsPadding()
+        ) {
+            HomeHeader(
+                // TODO Integrate in https://github.com/luongvo/kmm-survey/issues/13
+                dateTime = "Monday, JUNE 15",
+                avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+            )
+        }
     }
 }
 
@@ -30,6 +41,6 @@ fun HomeScreen(
 @Preview(showSystemUi = true)
 fun HomeScreenPreview() {
     ComposeTheme {
-        HomeScreen()
+        HomeScreenContent()
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -1,0 +1,67 @@
+package vn.luongvo.kmm.survey.android.ui.screens.home.views
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
+import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
+
+@Composable
+fun HomeHeader(
+    dateTime: String,
+    avatarUrl: String
+) {
+    Column(
+        modifier = Modifier
+            .padding(
+                start = dimensions.paddingMedium,
+                top = dimensions.paddingSmall,
+                end = dimensions.paddingMedium
+            ),
+    ) {
+        Text(
+            text = dateTime,
+            color = White,
+            style = typography.subtitle1,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = stringResource(id = R.string.home_today),
+                color = White,
+                style = typography.h4,
+            )
+            AsyncImage(
+                model = avatarUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(dimensions.avatarSize)
+                    .clip(CircleShape)
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun HomeHeaderPreview() {
+    ComposeTheme {
+        HomeHeader(
+            dateTime = "Monday, JUNE 15",
+            avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+        )
+    }
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
@@ -11,6 +11,7 @@ class AppDimensions {
 
     val inputHeight: Dp = 56.dp
     val buttonHeight: Dp = 56.dp
+    val avatarSize: Dp = 36.dp
 }
 
 internal val LocalAppDimensions = staticCompositionLocalOf { AppDimensions() }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="generic_error">Unexpected error!</string>
     <string name="generic_ok">OK</string>
 
+    <string name="home_today">Today</string>
+
     <string name="login_button">Log in</string>
     <string name="login_email">Email</string>
     <string name="login_forgot">Forgot?</string>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,6 +11,7 @@ object Versions {
 
     const val BUILD_KONFIG = "0.13.3"
 
+    const val COIL_COMPOSE = "2.2.2"
     const val COMPOSE_COMPILER = "1.3.2"
     const val COMPOSE_MATERIAL = "1.3.1"
     const val COMPOSE_NAVIGATION = "2.5.2"
@@ -71,6 +72,7 @@ object Dependencies {
         const val UI_TOOLING = "androidx.compose.ui:ui-tooling:${Versions.COMPOSE_UI}"
         const val MATERIAL = "androidx.compose.material:material:${Versions.COMPOSE_MATERIAL}"
         const val NAVIGATION = "androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION}"
+        const val COIL_COMPOSE = "io.coil-kt:coil-compose:${Versions.COIL_COMPOSE}"
     }
 
     object Firebase {


### PR DESCRIPTION
- Close #11

## What happened 👀

- Implement HomeHeader view UI.

## Insight 📝

- The demo gray background will lay out under the status bar.
- Use `Modifier.statusBarsPadding()` to move the Header to the bottom of the status bar.
- Use [Coil-Compose](https://coil-kt.github.io/coil/compose/) to build the user avatar from an URL.

## Proof Of Work 📹

<img src="https://user-images.githubusercontent.com/16315358/209701629-6c10f963-88a0-49f5-ac09-973d734fdb7d.png" width=300 />
