### PR TITLE
[#13] [Android] [Integrate] As a user, I can see the Home screen header

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
 
     with(Dependencies.AndroidX) {
         implementation(ACTIVITY_COMPOSE)
+        implementation(LIFECYCLE_RUNTIME_COMPOSE)
     }
     with(Dependencies.Compose) {
         implementation(UI)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/MyApplication.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/MyApplication.kt
@@ -3,8 +3,7 @@ package vn.luongvo.kmm.survey.android
 import android.app.Application
 import org.koin.android.ext.koin.androidContext
 import timber.log.Timber
-import vn.luongvo.kmm.survey.android.di.homeModule
-import vn.luongvo.kmm.survey.android.di.loginModule
+import vn.luongvo.kmm.survey.android.di.*
 import vn.luongvo.kmm.survey.di.initKoin
 
 class MyApplication : Application() {
@@ -15,6 +14,7 @@ class MyApplication : Application() {
             androidContext(applicationContext)
             modules(loginModule)
             modules(homeModule)
+            modules(helperModule)
         }
         setupLogging()
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/di/HelperModule.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/di/HelperModule.kt
@@ -1,0 +1,11 @@
+package vn.luongvo.kmm.survey.android.di
+
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+import vn.luongvo.kmm.survey.android.util.DateFormatter
+import vn.luongvo.kmm.survey.android.util.DateFormatterImpl
+
+val helperModule = module {
+    singleOf(::DateFormatterImpl) { bind<DateFormatter>() }
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/base/BaseViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/base/BaseViewModel.kt
@@ -2,7 +2,9 @@ package vn.luongvo.kmm.survey.android.ui.base
 
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import vn.luongvo.kmm.survey.android.lib.IsLoading
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 
@@ -14,7 +16,8 @@ abstract class BaseViewModel : ViewModel() {
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<IsLoading> = _isLoading
 
-    var error by mutableStateOf<Throwable?>(null)
+    protected val _error = MutableStateFlow<Throwable?>(null)
+    val error: StateFlow<Throwable?> = _error
 
     protected val _navigator = MutableSharedFlow<AppDestination>()
     val navigator: SharedFlow<AppDestination> = _navigator
@@ -42,4 +45,8 @@ abstract class BaseViewModel : ViewModel() {
     protected fun <T> Flow<T>.injectLoading(): Flow<T> = this
         .onStart { showLoading() }
         .onCompletion { hideLoading() }
+
+    fun clearError() {
+        viewModelScope.launch { _error.emit(null) }
+    }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/base/BaseViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/base/BaseViewModel.kt
@@ -12,14 +12,12 @@ abstract class BaseViewModel : ViewModel() {
     private var loadingCount: Int = 0
 
     private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<IsLoading>
-        get() = _isLoading
+    val isLoading: StateFlow<IsLoading> = _isLoading
 
     var error by mutableStateOf<Throwable?>(null)
 
     protected val _navigator = MutableSharedFlow<AppDestination>()
-    val navigator: SharedFlow<AppDestination>
-        get() = _navigator
+    val navigator: SharedFlow<AppDestination> = _navigator
 
     /**
      * To show loading manually, should call `hideLoading` after

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -37,6 +37,10 @@ fun HomeScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.init()
+    }
+
     HomeScreenContent(
         scaffoldState = scaffoldState,
         currentDate = currentDate,

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -25,17 +25,18 @@ const val HomeUserAvatar = "HomeUserAvatar"
 fun HomeScreen(
     viewModel: HomeViewModel = getViewModel()
 ) {
+    val error by viewModel.error.collectAsStateWithLifecycle()
     val currentDate by viewModel.currentDate.collectAsStateWithLifecycle()
     val avatarUrl by viewModel.avatarUrl.collectAsStateWithLifecycle()
 
     val scaffoldState: ScaffoldState = rememberScaffoldState()
     val context = LocalContext.current
-    LaunchedEffect(viewModel.error) {
-        viewModel.error?.let {
+    LaunchedEffect(error) {
+        error?.let {
             scaffoldState.snackbarHostState.showSnackbar(
                 message = it.userReadableMessage(context)
             )
-            viewModel.error = null
+            viewModel.clearError()
         }
     }
 

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.*
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
@@ -13,11 +15,17 @@ import vn.luongvo.kmm.survey.android.ui.screens.home.views.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel = getViewModel()
 ) {
+    val currentDate by viewModel.currentDate.collectAsStateWithLifecycle()
+    val avatarUrl by viewModel.avatarUrl.collectAsStateWithLifecycle()
+
     HomeScreenContent(
+        currentDate = currentDate,
+        avatarUrl = avatarUrl,
         // TODO Integrate in https://github.com/luongvo/kmm-survey/issues/16
         surveys = listOf(
             SurveyUiModel(
@@ -37,6 +45,8 @@ fun HomeScreen(
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 private fun HomeScreenContent(
+    currentDate: String,
+    avatarUrl: String,
     surveys: List<SurveyUiModel>
 ) {
     val pagerState = rememberPagerState()
@@ -64,9 +74,8 @@ private fun HomeScreenContent(
         }
 
         HomeHeader(
-            // TODO Integrate in https://github.com/luongvo/kmm-survey/issues/13
-            dateTime = "Monday, JUNE 15",
-            avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
+            dateTime = currentDate,
+            avatarUrl = avatarUrl,
             modifier = Modifier.statusBarsPadding()
         )
 
@@ -87,6 +96,8 @@ private fun HomeScreenContent(
 fun HomeScreenPreview() {
     ComposeTheme {
         HomeScreenContent(
+            currentDate = "Monday, JUNE 15",
+            avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
             surveys = listOf(
                 SurveyUiModel(
                     title = "Scarlett Bangkok",

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -18,6 +18,8 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.android.util.userReadableMessage
 
+const val HomeUserAvatar = "HomeUserAvatar"
+
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun HomeScreen(

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -32,14 +32,14 @@ class HomeViewModel(
         }
 
         getUserProfileUseCase()
-            .catch { e -> error = e }
+            .catch { e -> _error.emit(e) }
             .onEach {
                 _avatarUrl.emit(it.avatarUrl)
             }
             .launchIn(viewModelScope)
 
         getSurveysUseCase(pageNumber = 1, pageSize = 10)
-            .catch { e -> error = e }
+            .catch { e -> _error.emit(e) }
             .onEach {
                 // TODO Integrate getting user profile in https://github.com/luongvo/kmm-survey/issues/16
                 Timber.d(it.toString())

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -5,16 +5,17 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
+import vn.luongvo.kmm.survey.android.util.DateFormatter
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
 import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
-import java.text.SimpleDateFormat
 import java.util.*
 
 private const val HeaderDateFormat = "EEEE, MMMM d"
 
 class HomeViewModel(
     getUserProfileUseCase: GetUserProfileUseCase,
-    getSurveysUseCase: GetSurveysUseCase
+    getSurveysUseCase: GetSurveysUseCase,
+    dateFormatter: DateFormatter
 ) : BaseViewModel() {
 
     private val _currentDate = MutableStateFlow("")
@@ -25,7 +26,9 @@ class HomeViewModel(
 
     init {
         viewModelScope.launch {
-            _currentDate.emit(currentDate())
+            _currentDate.emit(
+                dateFormatter.format(Calendar.getInstance().time, HeaderDateFormat)
+            )
         }
 
         getUserProfileUseCase()
@@ -42,10 +45,5 @@ class HomeViewModel(
                 Timber.d(it.toString())
             }
             .launchIn(viewModelScope)
-    }
-
-    private fun currentDate(): String {
-        val now = Calendar.getInstance().time
-        return SimpleDateFormat(HeaderDateFormat, Locale.getDefault()).format(now)
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -2,34 +2,36 @@ package vn.luongvo.kmm.survey.android.ui.screens.home
 
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
 import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
+import java.text.SimpleDateFormat
+import java.util.*
+
+private const val HeaderDateFormat = "EEEE, MMMM d"
 
 class HomeViewModel(
     getUserProfileUseCase: GetUserProfileUseCase,
-    getSurveysUseCase: GetSurveysUseCase,
-//    tokenLocalDataSource: TokenLocalDataSource
+    getSurveysUseCase: GetSurveysUseCase
 ) : BaseViewModel() {
 
+    private val _currentDate = MutableStateFlow("")
+    val currentDate: StateFlow<String> = _currentDate
+
+    private val _avatarUrl = MutableStateFlow("")
+    val avatarUrl: StateFlow<String> = _avatarUrl
+
     init {
-        // TODO test code for POW, will remove it in the next PR
-//        tokenLocalDataSource.run {
-//            saveToken(
-//                Token(
-//                    tokenType,
-//                    "invalid_access_token",
-//                    refreshToken
-//                )
-//            )
-//        }
+        viewModelScope.launch {
+            _currentDate.emit(currentDate())
+        }
 
         getUserProfileUseCase()
             .catch { e -> error = e }
             .onEach {
-                // TODO Integrate getting user profile in https://github.com/luongvo/kmm-survey/issues/13
-                Timber.d(it.toString())
+                _avatarUrl.emit(it.avatarUrl)
             }
             .launchIn(viewModelScope)
 
@@ -40,5 +42,10 @@ class HomeViewModel(
                 Timber.d(it.toString())
             }
             .launchIn(viewModelScope)
+    }
+
+    private fun currentDate(): String {
+        val now = Calendar.getInstance().time
+        return SimpleDateFormat(HeaderDateFormat, Locale.getDefault()).format(now)
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -13,9 +13,9 @@ import java.util.*
 private const val HeaderDateFormat = "EEEE, MMMM d"
 
 class HomeViewModel(
-    getUserProfileUseCase: GetUserProfileUseCase,
-    getSurveysUseCase: GetSurveysUseCase,
-    dateFormatter: DateFormatter
+    private val getUserProfileUseCase: GetUserProfileUseCase,
+    private val getSurveysUseCase: GetSurveysUseCase,
+    private val dateFormatter: DateFormatter
 ) : BaseViewModel() {
 
     private val _currentDate = MutableStateFlow("")
@@ -24,7 +24,7 @@ class HomeViewModel(
     private val _avatarUrl = MutableStateFlow("")
     val avatarUrl: StateFlow<String> = _avatarUrl
 
-    init {
+    fun init() {
         viewModelScope.launch {
             _currentDate.emit(
                 dateFormatter.format(Calendar.getInstance().time, HeaderDateFormat)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -31,7 +31,7 @@ fun HomeHeader(
             ),
     ) {
         Text(
-            text = dateTime,
+            text = dateTime.uppercase(),
             color = White,
             style = typography.subtitle1,
         )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.screens.home.HomeUserAvatar
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
@@ -47,7 +48,7 @@ fun HomeHeader(
             )
             AsyncImage(
                 model = avatarUrl,
-                contentDescription = null,
+                contentDescription = HomeUserAvatar,
                 modifier = Modifier
                     .size(dimensions.avatarSize)
                     .clip(CircleShape)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.*
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.R
@@ -39,6 +41,7 @@ const val LastPhaseDurationInMilliseconds = 700
 private const val BlurRadius = 25f
 private val LogoOffset = Offset(0f, -229f)
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun LoginScreen(
     viewModel: LoginViewModel = getViewModel(),
@@ -46,8 +49,8 @@ fun LoginScreen(
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
-    val isLoading by viewModel.isLoading.collectAsState()
-    val isLoggedIn by viewModel.isLoggedIn.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     viewModel.error?.let {

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -50,13 +50,14 @@ fun LoginScreen(
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
     val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
-    viewModel.error?.let {
+    error?.let {
         AlertDialog(
             message = it.userReadableMessage(context),
-            onDismissRequest = { viewModel.error = null }
+            onDismissRequest = { viewModel.clearError() }
         )
     }
 

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginViewModel.kt
@@ -32,7 +32,7 @@ class LoginViewModel(
             password = password
         )
             .injectLoading()
-            .catch { e -> error = e }
+            .catch { e -> _error.emit(e) }
             .onEach {
                 _isLoggedIn.emit(true)
                 navigateToHome()

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppTypography.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppTypography.kt
@@ -24,7 +24,7 @@ private val Typography = Typography(
     ),
     subtitle1 = TextStyle(
         fontSize = 13.sp,
-        fontWeight = FontWeight.Bold
+        fontWeight = FontWeight.Normal
     ),
     h4 = TextStyle(
         fontSize = 34.sp,

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/util/DateFormatter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/util/DateFormatter.kt
@@ -1,0 +1,16 @@
+package vn.luongvo.kmm.survey.android.util
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+interface DateFormatter {
+
+    fun format(date: Date, dateFormat: String): String
+}
+
+class DateFormatterImpl : DateFormatter {
+
+    override fun format(date: Date, dateFormat: String): String {
+        return SimpleDateFormat(dateFormat, Locale.getDefault()).format(date)
+    }
+}

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
@@ -1,6 +1,6 @@
 package vn.luongvo.kmm.survey.android.test
 
-import vn.luongvo.kmm.survey.domain.model.Token
+import vn.luongvo.kmm.survey.domain.model.*
 
 object Fake {
 
@@ -9,4 +9,12 @@ object Fake {
         accessToken = "accessToken",
         refreshToken = "refreshToken"
     )
+
+    val user = User(
+        email = "email",
+        name = "name",
+        avatarUrl = "avatarUrl"
+    )
+
+    val surveys = emptyList<Survey>()
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -1,0 +1,77 @@
+package vn.luongvo.kmm.survey.android.ui.screens.home
+
+import android.content.Context
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.*
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.test.Fake
+import vn.luongvo.kmm.survey.android.util.DateFormatter
+import vn.luongvo.kmm.survey.domain.usecase.*
+
+@RunWith(AndroidJUnit4::class)
+class HomeScreenTest {
+
+    @get:Rule
+    val composeRule: ComposeContentTestRule = createComposeRule()
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val mockGetUserProfileUseCase: GetUserProfileUseCase = mockk()
+    private val mockGetSurveysUseCase: GetSurveysUseCase = mockk()
+    private val mockDateFormatter: DateFormatter = mockk()
+
+    private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setup() {
+        every { mockGetUserProfileUseCase() } returns flowOf(Fake.user)
+        every { mockGetSurveysUseCase(any(), any()) } returns flowOf(Fake.surveys)
+        every { mockDateFormatter.format(any(), any()) } returns "Thursday, December 29"
+
+        viewModel = HomeViewModel(
+            mockGetUserProfileUseCase,
+            mockGetSurveysUseCase,
+            mockDateFormatter
+        )
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `when entering the Home screen, it shows UI correctly`() = initComposable {
+        onNodeWithText("THURSDAY, DECEMBER 29").assertIsDisplayed()
+        onNodeWithText(context.getString(R.string.home_today)).assertIsDisplayed()
+        onNodeWithContentDescription(HomeUserAvatar).assertIsDisplayed()
+    }
+
+    @Test
+    fun `when getting user profile fails, it shows an error message`() {
+        val expectedError = Throwable("unexpected error")
+        every { mockGetUserProfileUseCase() } returns flow { throw expectedError }
+
+        initComposable {
+            onNodeWithText("unexpected error").assertIsDisplayed()
+        }
+    }
+
+    private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
+        composeRule.setContent {
+            HomeScreen(
+                viewModel = viewModel
+            )
+        }
+        testBody.invoke(composeRule)
+    }
+}

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -1,0 +1,53 @@
+package vn.luongvo.kmm.survey.android.ui.screens.home
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.*
+import vn.luongvo.kmm.survey.android.test.CoroutineTestRule
+import vn.luongvo.kmm.survey.android.test.Fake.surveys
+import vn.luongvo.kmm.survey.android.test.Fake.user
+import vn.luongvo.kmm.survey.android.util.DateFormatter
+import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
+import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
+
+@ExperimentalCoroutinesApi
+class HomeViewModelTest {
+
+    @get:Rule
+    val coroutinesRule = CoroutineTestRule()
+
+    private val mockGetUserProfileUseCase: GetUserProfileUseCase = mockk()
+    private val mockGetSurveysUseCase: GetSurveysUseCase = mockk()
+    private val mockDateFormatter: DateFormatter = mockk()
+
+    private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setUp() {
+        every { mockGetUserProfileUseCase() } returns flowOf(user)
+        every { mockGetSurveysUseCase(any(), any()) } returns flowOf(surveys)
+        every { mockDateFormatter.format(any(), any()) } returns "Thursday, December 29"
+
+        viewModel = HomeViewModel(
+            mockGetUserProfileUseCase,
+            mockGetSurveysUseCase,
+            mockDateFormatter
+        )
+    }
+
+    @Test
+    fun `when loading Home screen, it shows the current date time and user avatar`() = runTest {
+        viewModel.currentDate.test {
+            expectMostRecentItem() shouldBe "Thursday, December 29"
+        }
+
+        viewModel.avatarUrl.test {
+            expectMostRecentItem() shouldBe "avatarUrl"
+        }
+    }
+}

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -60,6 +60,8 @@ class HomeViewModelTest {
         every { mockGetUserProfileUseCase() } returns flow { throw error }
         viewModel.init()
 
-        viewModel.error shouldBe error
+        viewModel.error.test {
+            awaitItem() shouldBe error
+        }
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.*
@@ -42,6 +43,8 @@ class HomeViewModelTest {
 
     @Test
     fun `when loading Home screen, it shows the current date time and user avatar`() = runTest {
+        viewModel.init()
+
         viewModel.currentDate.test {
             expectMostRecentItem() shouldBe "Thursday, December 29"
         }
@@ -49,5 +52,14 @@ class HomeViewModelTest {
         viewModel.avatarUrl.test {
             expectMostRecentItem() shouldBe "avatarUrl"
         }
+    }
+
+    @Test
+    fun `when getting user profile fails, it shows the corresponding error`() = runTest {
+        val error = Exception()
+        every { mockGetUserProfileUseCase() } returns flow { throw error }
+        viewModel.init()
+
+        viewModel.error shouldBe error
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginViewModelTest.kt
@@ -72,7 +72,9 @@ class LoginViewModelTest {
         every { mockLogInUseCase(any(), any()) } returns flow { throw error }
         viewModel.logIn("email", "password")
 
-        viewModel.error shouldBe error
+        viewModel.error.test {
+            awaitItem() shouldBe error
+        }
     }
 
     @Test

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -7,6 +7,7 @@ object Versions {
     const val ANDROID_VERSION_NAME = "0.3.0"
 
     const val ANDROIDX_ACTIVITY_COMPOSE = "1.5.1"
+    const val ANDROIDX_LIFECYCLE_RUNTIME_COMPOSE = "2.6.0-alpha03"
     const val ANDROIDX_SECURITY_CRYPTO = "1.1.0-alpha04"
 
     const val BUILD_KONFIG = "0.13.3"
@@ -64,6 +65,8 @@ object Dependencies {
 
     object AndroidX {
         const val ACTIVITY_COMPOSE = "androidx.activity:activity-compose:${Versions.ANDROIDX_ACTIVITY_COMPOSE}"
+        const val LIFECYCLE_RUNTIME_COMPOSE =
+            "androidx.lifecycle:lifecycle-runtime-compose:${Versions.ANDROIDX_LIFECYCLE_RUNTIME_COMPOSE}"
         const val SECURITY_CRYPTO_KTX = "androidx.security:security-crypto-ktx:${Versions.ANDROIDX_SECURITY_CRYPTO}"
     }
 


### PR DESCRIPTION
- Close #13

## What happened 👀

After logging in, the user can see the Home screen with the user profile info:
- Show the `current date` in the left corner.
- Show the `user avatar` on the right.
- ~Refactor: body1 -> subtitle1, body2 -> subtitle2, subtitle1 -> body1.~ 👉  DROPPED
- Show an error message in case loading user project fails.
- Add UI tests for Home screen's header.

## Insight 📝

- As recommended in the latest update of `lifecycle-runtime-compose`, we should consume flows safely with [`collectAsStateWithLifecycle`](https://developer.android.com/reference/kotlin/androidx/lifecycle/compose/package-summary#(kotlinx.coroutines.flow.Flow).collectAsStateWithLifecycle(kotlin.Any,androidx.lifecycle.Lifecycle,androidx.lifecycle.Lifecycle.State,kotlin.coroutines.CoroutineContext)) https://medium.com/androiddevelopers/consuming-flows-safely-in-jetpack-compose-cde014d0d5a3.
- I added `DateFormatter` helper to make testing in HomeViewModel easier by mocking the current date data.
- Show error message as `Snackbar` https://medium.com/@jurajkunier/how-to-show-snackbar-in-jetpack-compose-3f2d81891f87.

## Proof Of Work 📹

- Success

<img src="https://user-images.githubusercontent.com/16315358/209897279-9cfeddfc-9e25-423e-9814-ed516ca9c991.png" width=300 />

- Failed to load user profile (no internet)

https://user-images.githubusercontent.com/16315358/209897324-7020a29b-45aa-4d2e-b422-b48017b198c8.mp4




