### PR TITLE
[#16] [Android] [Integrate] As a user, I can see a list of surveys on the home screen

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
         implementation(COIL_COMPOSE)
         implementation(ACCOMPANIST_PAGER)
         implementation(ACCOMPANIST_PAGER_INDICATORS)
+        implementation(ACCOMPANIST_PLACEHOLDER)
     }
     with(Dependencies.Firebase) {
         implementation(platform(FIREBASE_BOM))

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/extension/ModifierExt.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/extension/ModifierExt.kt
@@ -1,0 +1,21 @@
+package vn.luongvo.kmm.survey.android.extension
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.placeholder.*
+import vn.luongvo.kmm.survey.android.ui.theme.White50
+import vn.luongvo.kmm.survey.android.ui.theme.White70
+
+fun Modifier.placeholder(
+    isLoading: Boolean,
+    shapeValue: Dp = 100.dp // rounded corners shimmer item effect
+) = placeholder(
+    visible = isLoading,
+    color = White50,
+    shape = RoundedCornerShape(shapeValue),
+    highlight = PlaceholderHighlight.shimmer(
+        highlightColor = White70
+    )
+)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/NextCircleButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/NextCircleButton.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import vn.luongvo.kmm.survey.android.R
@@ -18,11 +20,14 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 
 @Composable
 fun NextCircleButton(
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    contentDescription: String = ""
 ) {
     Button(
         onClick = onClick,
-        modifier = Modifier.size(dimensions.buttonHeight),
+        modifier = Modifier
+            .size(dimensions.buttonHeight)
+            .semantics { this.contentDescription = contentDescription },
         shape = CircleShape,
         contentPadding = PaddingValues(0.dp),
         colors = ButtonDefaults.buttonColors(

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/providers/LoadingParameterProvider.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/providers/LoadingParameterProvider.kt
@@ -1,0 +1,11 @@
+package vn.luongvo.kmm.survey.android.ui.providers
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+
+class LoadingParameterProvider : PreviewParameterProvider<Boolean> {
+
+    override val values = sequenceOf(
+        false,
+        true
+    )
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -28,6 +28,7 @@ fun HomeScreen(
     val error by viewModel.error.collectAsStateWithLifecycle()
     val currentDate by viewModel.currentDate.collectAsStateWithLifecycle()
     val avatarUrl by viewModel.avatarUrl.collectAsStateWithLifecycle()
+    val surveys by viewModel.surveys.collectAsStateWithLifecycle()
 
     val scaffoldState: ScaffoldState = rememberScaffoldState()
     val context = LocalContext.current
@@ -48,19 +49,7 @@ fun HomeScreen(
         scaffoldState = scaffoldState,
         currentDate = currentDate,
         avatarUrl = avatarUrl,
-        // TODO Integrate in https://github.com/luongvo/kmm-survey/issues/16
-        surveys = listOf(
-            SurveyUiModel(
-                title = "Scarlett Bangkok",
-                description = "We'd love to hear from you!",
-                imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
-            ),
-            SurveyUiModel(
-                title = "ibis Bangkok Riverside",
-                description = "We'd love to hear from you!",
-                imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
-            )
-        )
+        surveys = surveys
     )
 }
 
@@ -76,10 +65,10 @@ private fun HomeScreenContent(
     var surveyTitle by remember { mutableStateOf("") }
     var surveyDescription by remember { mutableStateOf("") }
 
-    LaunchedEffect(pagerState) {
+    LaunchedEffect(surveys) {
         snapshotFlow { pagerState.currentPage }.collect { index ->
-            surveyTitle = surveys[index].title
-            surveyDescription = surveys[index].description
+            surveyTitle = surveys.getOrNull(index)?.title.orEmpty()
+            surveyDescription = surveys.getOrNull(index)?.description.orEmpty()
         }
     }
 
@@ -95,7 +84,7 @@ private fun HomeScreenContent(
                 modifier = Modifier.fillMaxSize()
             ) { index ->
                 DimmedImageBackground(
-                    imageUrl = surveys[index].imageUrl
+                    imageUrl = surveys[index].coverImageUrl
                 )
             }
 
@@ -130,12 +119,12 @@ fun HomeScreenPreview() {
                 SurveyUiModel(
                     title = "Scarlett Bangkok",
                     description = "We'd love to hear from you!",
-                    imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
+                    coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
                 ),
                 SurveyUiModel(
                     title = "ibis Bangkok Riverside",
                     description = "We'd love to hear from you!",
-                    imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
+                    coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
                 )
             )
         )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -16,7 +16,7 @@ import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
 import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.views.*
-import vn.luongvo.kmm.survey.android.ui.theme.AppTheme
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.android.util.userReadableMessage
 
@@ -98,7 +98,9 @@ private fun HomeScreenContent(
                 isLoading = isLoading,
                 dateTime = currentDate,
                 avatarUrl = avatarUrl,
-                modifier = Modifier.statusBarsPadding()
+                modifier = Modifier
+                    .statusBarsPadding()
+                    .padding(top = dimensions.paddingSmall)
             )
 
             HomeFooter(

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.android.util.userReadableMessage
 
 const val HomeUserAvatar = "HomeUserAvatar"
+const val HomeSurveyDetail = "HomeSurveyDetail"
 
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.*
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
+import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.views.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
@@ -26,6 +28,7 @@ const val HomeSurveyDetail = "HomeSurveyDetail"
 fun HomeScreen(
     viewModel: HomeViewModel = getViewModel()
 ) {
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
     val currentDate by viewModel.currentDate.collectAsStateWithLifecycle()
     val avatarUrl by viewModel.avatarUrl.collectAsStateWithLifecycle()
@@ -48,6 +51,7 @@ fun HomeScreen(
 
     HomeScreenContent(
         scaffoldState = scaffoldState,
+        isLoading = isLoading,
         currentDate = currentDate,
         avatarUrl = avatarUrl,
         surveys = surveys
@@ -58,6 +62,7 @@ fun HomeScreen(
 @Composable
 private fun HomeScreenContent(
     scaffoldState: ScaffoldState,
+    isLoading: Boolean,
     currentDate: String,
     avatarUrl: String,
     surveys: List<SurveyUiModel>
@@ -90,6 +95,7 @@ private fun HomeScreenContent(
             }
 
             HomeHeader(
+                isLoading = isLoading,
                 dateTime = currentDate,
                 avatarUrl = avatarUrl,
                 modifier = Modifier.statusBarsPadding()
@@ -97,12 +103,13 @@ private fun HomeScreenContent(
 
             HomeFooter(
                 pagerState = pagerState,
+                isLoading = isLoading,
                 title = surveyTitle,
                 description = surveyDescription,
                 modifier = Modifier
+                    .navigationBarsPadding()
                     .align(Alignment.BottomCenter)
-                    .padding(horizontal = AppTheme.dimensions.paddingMedium)
-                    .padding(bottom = 54.dp)
+                    .padding(bottom = 36.dp)
             )
         }
     }
@@ -110,10 +117,13 @@ private fun HomeScreenContent(
 
 @Preview(showSystemUi = true)
 @Composable
-fun HomeScreenPreview() {
+fun HomeScreenPreview(
+    @PreviewParameter(LoadingParameterProvider::class) isLoading: Boolean
+) {
     ComposeTheme {
         HomeScreenContent(
             scaffoldState = rememberScaffoldState(),
+            isLoading = isLoading,
             currentDate = "Monday, JUNE 15",
             avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
             surveys = listOf(

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -3,7 +3,6 @@ package vn.luongvo.kmm.survey.android.ui.screens.home
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
 import vn.luongvo.kmm.survey.android.util.DateFormatter
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
@@ -11,6 +10,8 @@ import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
 import java.util.*
 
 private const val HeaderDateFormat = "EEEE, MMMM d"
+private const val SurveyStartPageIndex = 1
+private const val SurveyPageSize = 10
 
 class HomeViewModel(
     private val getUserProfileUseCase: GetUserProfileUseCase,
@@ -23,6 +24,9 @@ class HomeViewModel(
 
     private val _avatarUrl = MutableStateFlow("")
     val avatarUrl: StateFlow<String> = _avatarUrl
+
+    private val _surveys = MutableStateFlow(emptyList<SurveyUiModel>())
+    val surveys: StateFlow<List<SurveyUiModel>> = _surveys
 
     fun init() {
         viewModelScope.launch {
@@ -38,11 +42,10 @@ class HomeViewModel(
             }
             .launchIn(viewModelScope)
 
-        getSurveysUseCase(pageNumber = 1, pageSize = 10)
+        getSurveysUseCase(pageNumber = SurveyStartPageIndex, pageSize = SurveyPageSize)
             .catch { e -> _error.emit(e) }
-            .onEach {
-                // TODO Integrate getting user profile in https://github.com/luongvo/kmm-survey/issues/16
-                Timber.d(it.toString())
+            .onEach { surveys ->
+                _surveys.emit(surveys.map { it.toUiModel() })
             }
             .launchIn(viewModelScope)
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -43,6 +43,7 @@ class HomeViewModel(
             .launchIn(viewModelScope)
 
         getSurveysUseCase(pageNumber = SurveyStartPageIndex, pageSize = SurveyPageSize)
+            .injectLoading()
             .catch { e -> _error.emit(e) }
             .onEach { surveys ->
                 _surveys.emit(surveys.map { it.toUiModel() })

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/SurveyUiModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/SurveyUiModel.kt
@@ -1,7 +1,15 @@
 package vn.luongvo.kmm.survey.android.ui.screens.home
 
+import vn.luongvo.kmm.survey.domain.model.Survey
+
 data class SurveyUiModel(
     val title: String,
     val description: String,
-    val imageUrl: String
+    val coverImageUrl: String
+)
+
+fun Survey.toUiModel() = SurveyUiModel(
+    title = title,
+    description = description,
+    coverImageUrl = coverImageUrl + "l"
 )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -18,6 +18,7 @@ import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeSurveyDetail
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
@@ -62,7 +63,7 @@ private fun HomeFooterContent(
         Text(
             text = it,
             color = White,
-            style = AppTheme.typography.h5,
+            style = typography.h5,
             maxLines = 4,
             overflow = TextOverflow.Ellipsis
         )
@@ -70,8 +71,7 @@ private fun HomeFooterContent(
     Spacer(modifier = Modifier.height(10.dp))
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Crossfade(
             targetState = description,
@@ -80,7 +80,7 @@ private fun HomeFooterContent(
             Text(
                 text = it,
                 color = White70,
-                style = AppTheme.typography.body1,
+                style = typography.body1,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -9,9 +9,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.*
+import vn.luongvo.kmm.survey.android.extension.placeholder
 import vn.luongvo.kmm.survey.android.ui.common.NextCircleButton
+import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeSurveyDetail
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
@@ -20,62 +23,121 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 @Composable
 fun HomeFooter(
     pagerState: PagerState,
+    isLoading: Boolean,
     title: String,
     description: String,
     modifier: Modifier
 ) {
-    Column(modifier = modifier) {
-        HorizontalPagerIndicator(
-            pagerState = pagerState,
-            activeColor = White,
-            inactiveColor = White20,
-            modifier = Modifier.padding(vertical = dimensions.paddingLarge),
-        )
-        Crossfade(targetState = title) {
-            Text(
-                text = it,
-                color = White,
-                style = AppTheme.typography.h5,
-                maxLines = 4,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Crossfade(
-                targetState = description,
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = it,
-                    color = White70,
-                    style = AppTheme.typography.body1,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Spacer(modifier = Modifier.width(dimensions.paddingMedium))
-            NextCircleButton(
-                onClick = {
-                    // TODO navigate to Survey Detail screen
-                },
-                contentDescription = HomeSurveyDetail
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = dimensions.paddingMedium)
+    ) {
+        if (isLoading) {
+            HomeFooterLoadingContent()
+        } else {
+            HomeFooterContent(
+                pagerState = pagerState,
+                title = title,
+                description = description
             )
         }
     }
 }
 
 @OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun HomeFooterContent(
+    pagerState: PagerState,
+    title: String,
+    description: String
+) {
+    HorizontalPagerIndicator(
+        pagerState = pagerState,
+        activeColor = White,
+        inactiveColor = White20,
+        modifier = Modifier.padding(vertical = dimensions.paddingLarge),
+    )
+    Crossfade(targetState = title) {
+        Text(
+            text = it,
+            color = White,
+            style = AppTheme.typography.h5,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+    Spacer(modifier = Modifier.height(10.dp))
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Crossfade(
+            targetState = description,
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = it,
+                color = White70,
+                style = AppTheme.typography.body1,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Spacer(modifier = Modifier.width(dimensions.paddingMedium))
+        NextCircleButton(
+            onClick = {
+                // TODO navigate to Survey Detail screen
+            },
+            contentDescription = HomeSurveyDetail
+        )
+    }
+}
+
+@Composable
+private fun HomeFooterLoadingContent() {
+    Spacer(
+        modifier = Modifier
+            .size(30.dp, 14.dp)
+            .placeholder(true)
+    )
+    Spacer(modifier = Modifier.height(10.dp))
+    Spacer(
+        modifier = Modifier
+            .size(240.dp, 18.dp)
+            .placeholder(true)
+    )
+    Spacer(modifier = Modifier.height(5.dp))
+    Spacer(
+        modifier = Modifier
+            .size(120.dp, 18.dp)
+            .placeholder(true)
+    )
+    Spacer(modifier = Modifier.height(10.dp))
+    Spacer(
+        modifier = Modifier
+            .size(300.dp, 18.dp)
+            .placeholder(true)
+    )
+    Spacer(modifier = Modifier.height(5.dp))
+    Spacer(
+        modifier = Modifier
+            .size(200.dp, 18.dp)
+            .placeholder(true)
+    )
+}
+
+@OptIn(ExperimentalPagerApi::class)
 @Preview
 @Composable
-fun HomeFooterPreview() {
+fun HomeFooterPreview(
+    @PreviewParameter(LoadingParameterProvider::class) isLoading: Boolean
+) {
     ComposeTheme {
         HomeFooter(
             pagerState = rememberPagerState(),
+            isLoading = isLoading,
             title = "ibis Bangkok Riverside",
             description = "We'd love to hear from you!",
             modifier = Modifier.wrapContentHeight()

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.*
 import vn.luongvo.kmm.survey.android.ui.common.NextCircleButton
+import vn.luongvo.kmm.survey.android.ui.screens.home.HomeSurveyDetail
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 
@@ -62,6 +63,7 @@ fun HomeFooter(
                 onClick = {
                     // TODO navigate to Survey Detail screen
                 },
+                contentDescription = HomeSurveyDetail
             )
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -28,12 +28,7 @@ fun HomeHeader(
     modifier: Modifier
 ) {
     Column(
-        modifier = modifier
-            .padding(
-                start = dimensions.paddingMedium,
-                top = dimensions.paddingSmall,
-                end = dimensions.paddingMedium
-            ),
+        modifier = modifier.padding(horizontal = dimensions.paddingMedium)
     ) {
         Text(
             text = dateTime.uppercase(),

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -9,9 +9,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.extension.placeholder
+import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeUserAvatar
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
@@ -19,6 +22,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
 @Composable
 fun HomeHeader(
+    isLoading: Boolean,
     dateTime: String,
     avatarUrl: String,
     modifier: Modifier
@@ -35,6 +39,7 @@ fun HomeHeader(
             text = dateTime.uppercase(),
             color = White,
             style = typography.subtitle1,
+            modifier = Modifier.placeholder(isLoading = isLoading)
         )
         Spacer(modifier = Modifier.height(4.dp))
         Row(
@@ -45,6 +50,7 @@ fun HomeHeader(
                 text = stringResource(id = R.string.home_today),
                 color = White,
                 style = typography.h4,
+                modifier = Modifier.placeholder(isLoading = isLoading)
             )
             AsyncImage(
                 model = avatarUrl,
@@ -52,6 +58,7 @@ fun HomeHeader(
                 modifier = Modifier
                     .size(dimensions.avatarSize)
                     .clip(CircleShape)
+                    .placeholder(isLoading = isLoading)
             )
         }
     }
@@ -59,9 +66,12 @@ fun HomeHeader(
 
 @Preview
 @Composable
-fun HomeHeaderPreview() {
+fun HomeHeaderPreview(
+    @PreviewParameter(LoadingParameterProvider::class) isLoading: Boolean
+) {
     ComposeTheme {
         HomeHeader(
+            isLoading = isLoading,
             dateTime = "Monday, JUNE 15",
             avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
             modifier = Modifier.wrapContentHeight()

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.*
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -25,6 +26,7 @@ import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
+import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
@@ -227,7 +229,9 @@ private fun LoginForm(
 
 @Preview(showSystemUi = true)
 @Composable
-fun LoginScreenPreview() {
+fun LoginScreenPreview(
+    @PreviewParameter(LoadingParameterProvider::class) isLoading: Boolean
+) {
     ComposeTheme {
         LoginScreenContent(
             email = "",
@@ -235,7 +239,7 @@ fun LoginScreenPreview() {
             onEmailChange = {},
             onPasswordChange = {},
             onLogInClick = {},
-            isLoading = false,
+            isLoading = isLoading,
             initialLogoVisible = true,
             initialLogoOffset = LogoOffset,
             initialLogoScale = 1f,

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
@@ -26,7 +26,7 @@ object Fake {
         Survey(
             id = "2",
             title = "ibis Bangkok Riverside",
-            description = "We'd love to hear from you!",
+            description = "We'd like to hear from you!",
             coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
         )
     )

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
@@ -16,5 +16,18 @@ object Fake {
         avatarUrl = "avatarUrl"
     )
 
-    val surveys = emptyList<Survey>()
+    val surveys = listOf(
+        Survey(
+            id = "1",
+            title = "Scarlett Bangkok",
+            description = "We'd love to hear from you!",
+            coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
+        ),
+        Survey(
+            id = "2",
+            title = "ibis Bangkok Riverside",
+            description = "We'd love to hear from you!",
+            coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
+        )
+    )
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -4,10 +4,11 @@ import app.cash.turbine.test
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.*
 import org.junit.*
 import vn.luongvo.kmm.survey.android.test.CoroutineTestRule
 import vn.luongvo.kmm.survey.android.test.Fake.surveys
@@ -86,5 +87,18 @@ class HomeViewModelTest {
         viewModel.init()
 
         viewModel.error shouldBe error
+    }
+
+    @Test
+    fun `When getting surveys, it shows and hides loading correctly`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher())
+
+        viewModel.isLoading.test {
+            viewModel.init()
+
+            awaitItem() shouldBe false
+            awaitItem() shouldBe true
+            awaitItem() shouldBe false
+        }
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -48,6 +48,11 @@ class HomeViewModelTest {
         viewModel.currentDate.test {
             expectMostRecentItem() shouldBe "Thursday, December 29"
         }
+    }
+
+    @Test
+    fun `when getting user profile successfully, it shows the user avatar`() = runTest {
+        viewModel.init()
 
         viewModel.avatarUrl.test {
             expectMostRecentItem() shouldBe "avatarUrl"
@@ -63,5 +68,23 @@ class HomeViewModelTest {
         viewModel.error.test {
             awaitItem() shouldBe error
         }
+    }
+
+    @Test
+    fun `when getting surveys successfully, it shows the survey list`() = runTest {
+        viewModel.init()
+
+        viewModel.surveys.test {
+            expectMostRecentItem() shouldBe surveys.map { it.toUiModel() }
+        }
+    }
+
+    @Test
+    fun `when getting surveys fails, it shows the corresponding error`() = runTest {
+        val error = Exception()
+        every { mockGetSurveysUseCase(any(), any()) } returns flow { throw error }
+        viewModel.init()
+
+        viewModel.error shouldBe error
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -86,7 +86,9 @@ class HomeViewModelTest {
         every { mockGetSurveysUseCase(any(), any()) } returns flow { throw error }
         viewModel.init()
 
-        viewModel.error shouldBe error
+        viewModel.error.test {
+            awaitItem() shouldBe error
+        }
     }
 
     @Test

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
@@ -107,7 +107,9 @@ class LoginScreenTest {
             ComposeTheme {
                 LoginScreen(
                     viewModel = viewModel,
-                    navigator = { destination -> expectedAppDestination = destination }
+                    navigator = { destination ->
+                        expectedAppDestination = destination
+                    }
                 )
             }
         }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import org.koin.core.context.stopKoin
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
+import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.domain.exceptions.ApiException
 import vn.luongvo.kmm.survey.domain.usecase.IsLoggedInUseCase
 import vn.luongvo.kmm.survey.domain.usecase.LogInUseCase
@@ -103,10 +104,12 @@ class LoginScreenTest {
 
     private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
         composeRule.setContent {
-            LoginScreen(
-                viewModel = viewModel,
-                navigator = { destination -> expectedAppDestination = destination }
-            )
+            ComposeTheme {
+                LoginScreen(
+                    viewModel = viewModel,
+                    navigator = { destination -> expectedAppDestination = destination }
+                )
+            }
         }
         testBody.invoke(composeRule)
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -80,6 +80,8 @@ object Dependencies {
         const val ACCOMPANIST_PAGER = "com.google.accompanist:accompanist-pager:${Versions.COMPOSE_ACCOMPANIST}"
         const val ACCOMPANIST_PAGER_INDICATORS =
             "com.google.accompanist:accompanist-pager-indicators:${Versions.COMPOSE_ACCOMPANIST}"
+        const val ACCOMPANIST_PLACEHOLDER =
+            "com.google.accompanist:accompanist-placeholder:${Versions.COMPOSE_ACCOMPANIST}"
     }
 
     object Firebase {


### PR DESCRIPTION
- Close #16

## What happened 👀

 - Integrate to bind survey list into pager on the Home screen.
 - Show the error Snackbar when an error occurs.
 - Show the shimmer loading effect while loading user profile & survey list.
 - Add necessary unit tests & UI tests.
 
## Insight 📝

- Use [Accompanist placeholder](https://google.github.io/accompanist/placeholder/) to build the shimmer effect. The header text has the texts so we don't need to implement a separate loading content for it.
- Add `LoadingParameterProvider` to automate providing more loading preview states.

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/209942058-9124e72f-8b1a-4c56-a746-dd45e26000c8.mp4


