### PR TITLE
[#21] [Android] [UI] As a user, I can see the Survey Detail screen

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/BackButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/BackButton.kt
@@ -1,0 +1,44 @@
+package vn.luongvo.kmm.survey.android.ui.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
+
+private const val Rotate180 = 180f
+
+@Composable
+fun BackButton(
+    modifier: Modifier,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .wrapContentSize()
+            .rotate(Rotate180), // switch Right Arrow to Back button
+        contentPadding = PaddingValues(dimensions.paddingMedium),
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = Transparent
+        ),
+        elevation = null
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_arrow_right),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(Color.White),
+            contentScale = ContentScale.FillWidth
+        )
+    }
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
@@ -5,8 +5,6 @@ import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.shapes
@@ -17,8 +15,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.BlackRussian
 fun PrimaryButton(
     text: String,
     onClick: () -> Unit,
-    modifier: Modifier,
-    contentDescription: String = ""
+    modifier: Modifier
 ) {
     Button(
         shape = shapes.medium,
@@ -27,9 +24,7 @@ fun PrimaryButton(
             backgroundColor = White
         ),
         contentPadding = PaddingValues(horizontal = dimensions.paddingLarge),
-        modifier = modifier
-            .height(dimensions.buttonHeight)
-            .semantics { this.contentDescription = contentDescription }
+        modifier = modifier.height(dimensions.buttonHeight)
     ) {
         Text(
             text = text,

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
@@ -1,7 +1,6 @@
 package vn.luongvo.kmm.survey.android.ui.common
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,6 +17,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.BlackRussian
 fun PrimaryButton(
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier,
     contentDescription: String = ""
 ) {
     Button(
@@ -26,8 +26,8 @@ fun PrimaryButton(
         colors = ButtonDefaults.buttonColors(
             backgroundColor = White
         ),
-        modifier = Modifier
-            .fillMaxWidth()
+        contentPadding = PaddingValues(horizontal = dimensions.paddingLarge),
+        modifier = modifier
             .height(dimensions.buttonHeight)
             .semantics { this.contentDescription = contentDescription }
     ) {
@@ -44,6 +44,7 @@ fun PrimaryButton(
 fun PrimaryButtonPreview() {
     PrimaryButton(
         text = "Button Text",
-        onClick = {}
+        onClick = {},
+        modifier = Modifier.fillMaxWidth()
     )
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppDestination.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppDestination.kt
@@ -1,6 +1,8 @@
 package vn.luongvo.kmm.survey.android.ui.navigation
 
-import androidx.navigation.NamedNavArgument
+import androidx.navigation.*
+
+const val SurveyIdArg = "surveyId"
 
 sealed class AppDestination(val route: String = "") {
 
@@ -13,5 +15,17 @@ sealed class AppDestination(val route: String = "") {
     object Up : AppDestination()
 
     object Login : AppDestination("login")
+
     object Home : AppDestination("home")
+
+    object Survey : AppDestination("survey/{$SurveyIdArg}") {
+
+        override val arguments = listOf(
+            navArgument(SurveyIdArg) { type = NavType.StringType }
+        )
+
+        fun buildDestination(surveyId: String) = apply {
+            destination = "survey/$surveyId"
+        }
+    }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
@@ -28,7 +28,8 @@ fun AppNavigation(
         }
         composable(AppDestination.Survey) { backStackEntry ->
             SurveyScreen(
-                surveyId = backStackEntry.arguments?.getString(SurveyIdArg).orEmpty()
+                surveyId = backStackEntry.arguments?.getString(SurveyIdArg).orEmpty(),
+                navigator = { destination -> navController.navigate(destination) }
             )
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.*
 import androidx.navigation.compose.*
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeScreen
 import vn.luongvo.kmm.survey.android.ui.screens.login.LoginScreen
+import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyScreen
 
 @Composable
 fun AppNavigation(
@@ -22,8 +23,12 @@ fun AppNavigation(
         }
         composable(AppDestination.Home) {
             HomeScreen(
-                // TODO handle navigation later
-                // navigator = { destination -> navController.navigate(destination) }
+                navigator = { destination -> navController.navigate(destination) }
+            )
+        }
+        composable(AppDestination.Survey) { backStackEntry ->
+            SurveyScreen(
+                surveyId = backStackEntry.arguments?.getString(SurveyIdArg).orEmpty()
             )
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.*
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
+import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.views.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
@@ -26,7 +27,8 @@ const val HomeSurveyDetail = "HomeSurveyDetail"
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun HomeScreen(
-    viewModel: HomeViewModel = getViewModel()
+    viewModel: HomeViewModel = getViewModel(),
+    navigator: (destination: AppDestination) -> Unit
 ) {
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
@@ -45,6 +47,10 @@ fun HomeScreen(
         }
     }
 
+    LaunchedEffect(viewModel.navigator) {
+        viewModel.navigator.collect { destination -> navigator(destination) }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.init()
     }
@@ -54,7 +60,8 @@ fun HomeScreen(
         isLoading = isLoading,
         currentDate = currentDate,
         avatarUrl = avatarUrl,
-        surveys = surveys
+        surveys = surveys,
+        onSurveyClick = { survey -> viewModel.navigateToSurvey(survey?.id.orEmpty()) }
     )
 }
 
@@ -65,16 +72,15 @@ private fun HomeScreenContent(
     isLoading: Boolean,
     currentDate: String,
     avatarUrl: String,
-    surveys: List<SurveyUiModel>
+    surveys: List<SurveyUiModel>,
+    onSurveyClick: (SurveyUiModel?) -> Unit
 ) {
     val pagerState = rememberPagerState()
-    var surveyTitle by remember { mutableStateOf("") }
-    var surveyDescription by remember { mutableStateOf("") }
+    var survey by remember { mutableStateOf<SurveyUiModel?>(null) }
 
     LaunchedEffect(surveys) {
         snapshotFlow { pagerState.currentPage }.collect { index ->
-            surveyTitle = surveys.getOrNull(index)?.title.orEmpty()
-            surveyDescription = surveys.getOrNull(index)?.description.orEmpty()
+            survey = surveys.getOrNull(index)
         }
     }
 
@@ -106,12 +112,12 @@ private fun HomeScreenContent(
             HomeFooter(
                 pagerState = pagerState,
                 isLoading = isLoading,
-                title = surveyTitle,
-                description = surveyDescription,
+                survey = survey,
                 modifier = Modifier
                     .navigationBarsPadding()
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 36.dp)
+                    .padding(bottom = 36.dp),
+                onSurveyClick = onSurveyClick
             )
         }
     }
@@ -130,16 +136,18 @@ fun HomeScreenPreview(
             avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
             surveys = listOf(
                 SurveyUiModel(
+                    id = "1",
                     title = "Scarlett Bangkok",
                     description = "We'd love to hear from you!",
                     coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
                 ),
                 SurveyUiModel(
+                    id = "2",
                     title = "ibis Bangkok Riverside",
                     description = "We'd love to hear from you!",
                     coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
                 )
             )
-        )
+        ) {}
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.*
@@ -116,7 +115,7 @@ private fun HomeScreenContent(
                 modifier = Modifier
                     .navigationBarsPadding()
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 36.dp),
+                    .padding(bottom = dimensions.paddingLargest),
                 onSurveyClick = onSurveyClick
             )
         }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
+import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.util.DateFormatter
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
 import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
@@ -49,5 +50,11 @@ class HomeViewModel(
                 _surveys.emit(surveys.map { it.toUiModel() })
             }
             .launchIn(viewModelScope)
+    }
+
+    fun navigateToSurvey(surveyId: String) {
+        viewModelScope.launch {
+            _navigator.emit(AppDestination.Survey.buildDestination(surveyId))
+        }
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/SurveyUiModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/SurveyUiModel.kt
@@ -3,12 +3,14 @@ package vn.luongvo.kmm.survey.android.ui.screens.home
 import vn.luongvo.kmm.survey.domain.model.Survey
 
 data class SurveyUiModel(
+    val id: String,
     val title: String,
     val description: String,
     val coverImageUrl: String
 )
 
 fun Survey.toUiModel() = SurveyUiModel(
+    id = id,
     title = title,
     description = description,
     coverImageUrl = coverImageUrl + "l"

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -88,7 +88,7 @@ private fun HomeFooterContent(
         }
         Spacer(modifier = Modifier.width(dimensions.paddingMedium))
         NextCircleButton(
-            onClick = { onSurveyClick.invoke(survey) },
+            onClick = { onSurveyClick(survey) },
             contentDescription = HomeSurveyDetail
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -65,7 +65,7 @@ private fun HomeFooterContent(
             text = it.orEmpty(),
             color = White,
             style = typography.h5,
-            maxLines = 4,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -16,6 +16,7 @@ import vn.luongvo.kmm.survey.android.extension.placeholder
 import vn.luongvo.kmm.survey.android.ui.common.NextCircleButton
 import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeSurveyDetail
+import vn.luongvo.kmm.survey.android.ui.screens.home.SurveyUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
@@ -25,9 +26,9 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 fun HomeFooter(
     pagerState: PagerState,
     isLoading: Boolean,
-    title: String,
-    description: String,
-    modifier: Modifier
+    survey: SurveyUiModel?,
+    modifier: Modifier,
+    onSurveyClick: (SurveyUiModel?) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -39,8 +40,8 @@ fun HomeFooter(
         } else {
             HomeFooterContent(
                 pagerState = pagerState,
-                title = title,
-                description = description
+                survey = survey,
+                onSurveyClick = onSurveyClick
             )
         }
     }
@@ -50,8 +51,8 @@ fun HomeFooter(
 @Composable
 private fun HomeFooterContent(
     pagerState: PagerState,
-    title: String,
-    description: String
+    survey: SurveyUiModel?,
+    onSurveyClick: (SurveyUiModel?) -> Unit
 ) {
     HorizontalPagerIndicator(
         pagerState = pagerState,
@@ -59,9 +60,9 @@ private fun HomeFooterContent(
         inactiveColor = White20,
         modifier = Modifier.padding(vertical = dimensions.paddingLarge),
     )
-    Crossfade(targetState = title) {
+    Crossfade(targetState = survey?.title) {
         Text(
-            text = it,
+            text = it.orEmpty(),
             color = White,
             style = typography.h5,
             maxLines = 4,
@@ -74,11 +75,11 @@ private fun HomeFooterContent(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Crossfade(
-            targetState = description,
+            targetState = survey?.description,
             modifier = Modifier.weight(1f)
         ) {
             Text(
-                text = it,
+                text = it.orEmpty(),
                 color = White70,
                 style = typography.body1,
                 maxLines = 2,
@@ -87,9 +88,7 @@ private fun HomeFooterContent(
         }
         Spacer(modifier = Modifier.width(dimensions.paddingMedium))
         NextCircleButton(
-            onClick = {
-                // TODO navigate to Survey Detail screen
-            },
+            onClick = { onSurveyClick.invoke(survey) },
             contentDescription = HomeSurveyDetail
         )
     }
@@ -138,9 +137,13 @@ fun HomeFooterPreview(
         HomeFooter(
             pagerState = rememberPagerState(),
             isLoading = isLoading,
-            title = "ibis Bangkok Riverside",
-            description = "We'd love to hear from you!",
+            survey = SurveyUiModel(
+                id = "1",
+                title = "Scarlett Bangkok",
+                description = "We'd love to hear from you!",
+                coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
+            ),
             modifier = Modifier.wrapContentHeight()
-        )
+        ) {}
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.*
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -222,8 +224,9 @@ private fun LoginForm(
         PrimaryButton(
             text = stringResource(id = R.string.login_button),
             onClick = onLogInClick,
-            modifier = Modifier.fillMaxWidth(),
-            contentDescription = LoginButton
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { this.contentDescription = LoginButton },
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -222,6 +222,7 @@ private fun LoginForm(
         PrimaryButton(
             text = stringResource(id = R.string.login_button),
             onClick = onLogInClick,
+            modifier = Modifier.fillMaxWidth(),
             contentDescription = LoginButton
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
 import vn.luongvo.kmm.survey.android.ui.common.PrimaryButton
+import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
@@ -26,12 +27,11 @@ import vn.luongvo.kmm.survey.android.ui.theme.White70
 
 @Composable
 fun SurveyScreen(
-    surveyId: String
+    surveyId: String,
+    navigator: (destination: AppDestination) -> Unit
 ) {
     SurveyScreenContent(
-        onBackClick = {
-            // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-        },
+        onBackClick = { navigator(AppDestination.Up) },
         onStartClick = {
             // TODO start survey
         }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -1,28 +1,112 @@
 package vn.luongvo.kmm.survey.android.ui.screens.survey
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
+import vn.luongvo.kmm.survey.android.ui.common.PrimaryButton
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
+import vn.luongvo.kmm.survey.android.ui.theme.White70
 
 @Composable
 fun SurveyScreen(
     surveyId: String
 ) {
-    SurveyScreenContent(surveyId)
+    SurveyScreenContent(
+        onBackClick = {
+            // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+        },
+        onStartClick = {
+            // TODO start survey
+        }
+    )
 }
 
 @Composable
-private fun SurveyScreenContent(surveyId: String) {
+private fun SurveyScreenContent(
+    onBackClick: () -> Unit,
+    onStartClick: () -> Unit
+) {
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
         DimmedImageBackground(
-            imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
+            // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+            imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
         )
+
+        Button(
+            onClick = onBackClick,
+            modifier = Modifier
+                .statusBarsPadding()
+                .wrapContentSize()
+                .rotate(180f) // switch Right Arrow to Back button
+                .padding(vertical = 5.dp),
+            contentPadding = PaddingValues(dimensions.paddingMedium),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = Transparent
+            ),
+            elevation = null
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_arrow_right),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(White),
+                contentScale = ContentScale.FillWidth
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .fillMaxWidth()
+                .padding(top = 70.dp)
+                .padding(horizontal = dimensions.paddingMedium)
+        ) {
+            Text(
+                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+                text = "Scarlett Bangkok",
+                color = White,
+                style = typography.h4,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(dimensions.paddingSmall))
+            Text(
+                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+                text = "We'd love to hear from you!",
+                color = White70,
+                style = typography.body1,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            PrimaryButton(
+                text = stringResource(id = R.string.survey_start),
+                onClick = onStartClick,
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .align(Alignment.End)
+                    .padding(bottom = dimensions.paddingLargest)
+            )
+        }
     }
 }
 
@@ -30,6 +114,9 @@ private fun SurveyScreenContent(surveyId: String) {
 @Composable
 fun SurveyScreenPreview() {
     ComposeTheme {
-        SurveyScreenContent("surveyId")
+        SurveyScreenContent(
+            onBackClick = {},
+            onStartClick = {}
+        )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -1,17 +1,11 @@
 package vn.luongvo.kmm.survey.android.ui.screens.survey
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color.Companion.Transparent
 import androidx.compose.ui.graphics.Color.Companion.White
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -19,8 +13,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import vn.luongvo.kmm.survey.android.R
-import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
-import vn.luongvo.kmm.survey.android.ui.common.PrimaryButton
+import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
@@ -55,27 +48,13 @@ private fun SurveyScreenContent(
             imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
         )
 
-        Button(
-            onClick = onBackClick,
+        BackButton(
             modifier = Modifier
                 .statusBarsPadding()
-                .wrapContentSize()
-                .rotate(180f) // switch Right Arrow to Back button
                 .padding(vertical = 5.dp)
                 .semantics { this.contentDescription = SurveyBackButton },
-            contentPadding = PaddingValues(dimensions.paddingMedium),
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = Transparent
-            ),
-            elevation = null
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_arrow_right),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(White),
-                contentScale = ContentScale.FillWidth
-            )
-        }
+            onClick = onBackClick
+        )
 
         Column(
             modifier = Modifier

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -1,11 +1,11 @@
 package vn.luongvo.kmm.survey.android.ui.screens.survey
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
 @Composable
@@ -17,15 +17,11 @@ fun SurveyScreen(
 
 @Composable
 private fun SurveyScreenContent(surveyId: String) {
-    Column(
+    Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        Text(
-            text = "Survey ID: $surveyId",
-            color = Color.White,
-            modifier = Modifier
-                .fillMaxSize()
-                .wrapContentSize()
+        DimmedImageBackground(
+            imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,6 +26,8 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.android.ui.theme.White70
+
+const val SurveyBackButton = "SurveyBackButton"
 
 @Composable
 fun SurveyScreen(
@@ -57,7 +61,8 @@ private fun SurveyScreenContent(
                 .statusBarsPadding()
                 .wrapContentSize()
                 .rotate(180f) // switch Right Arrow to Back button
-                .padding(vertical = 5.dp),
+                .padding(vertical = 5.dp)
+                .semantics { this.contentDescription = SurveyBackButton },
             contentPadding = PaddingValues(dimensions.paddingMedium),
             colors = ButtonDefaults.buttonColors(
                 backgroundColor = Transparent

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -1,0 +1,39 @@
+package vn.luongvo.kmm.survey.android.ui.screens.survey
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
+
+@Composable
+fun SurveyScreen(
+    surveyId: String
+) {
+    SurveyScreenContent(surveyId)
+}
+
+@Composable
+private fun SurveyScreenContent(surveyId: String) {
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            text = "Survey ID: $surveyId",
+            color = Color.White,
+            modifier = Modifier
+                .fillMaxSize()
+                .wrapContentSize()
+        )
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun SurveyScreenPreview() {
+    ComposeTheme {
+        SurveyScreenContent("surveyId")
+    }
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
@@ -8,6 +8,7 @@ class AppDimensions {
     val paddingSmall: Dp = 16.dp
     val paddingMedium: Dp = 20.dp
     val paddingLarge: Dp = 24.dp
+    val paddingLargest: Dp = 36.dp
 
     val inputHeight: Dp = 56.dp
     val buttonHeight: Dp = 56.dp

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
     <string name="login_email">Email</string>
     <string name="login_forgot">Forgot?</string>
     <string name="login_password">Password</string>
+
+    <string name="survey_start">Start Survey</string>
 </resources>

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.*
+import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.koin.core.context.stopKoin
 import vn.luongvo.kmm.survey.android.R
@@ -101,7 +102,7 @@ class HomeScreenTest {
     fun `when clicking on the Next button on each survey, it navigates to the Survey screen`() = initComposable {
         onNodeWithContentDescription(HomeSurveyDetail).performClick()
 
-        Assert.assertEquals(expectedAppDestination, AppDestination.Survey)
+        assertEquals(expectedAppDestination, AppDestination.Survey)
     }
 
     private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -15,6 +15,7 @@ import org.koin.core.context.stopKoin
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.test.Fake.surveys
 import vn.luongvo.kmm.survey.android.test.Fake.user
+import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 import vn.luongvo.kmm.survey.android.util.DateFormatter
 import vn.luongvo.kmm.survey.domain.usecase.*
@@ -32,6 +33,7 @@ class HomeScreenTest {
     private val mockDateFormatter: DateFormatter = mockk()
 
     private lateinit var viewModel: HomeViewModel
+    private var expectedAppDestination: AppDestination? = null
 
     @Before
     fun setup() {
@@ -95,14 +97,22 @@ class HomeScreenTest {
         }
     }
 
+    @Test
+    fun `when clicking on the Next button on each survey, it navigates to the Survey screen`() = initComposable {
+        onNodeWithContentDescription(HomeSurveyDetail).performClick()
+
+        Assert.assertEquals(expectedAppDestination, AppDestination.Survey)
+    }
+
     private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
         composeRule.setContent {
             ComposeTheme {
                 HomeScreen(
-                    viewModel = viewModel
+                    viewModel = viewModel,
+                    navigator = { destination -> expectedAppDestination = destination }
                 )
             }
         }
-        testBody.invoke(composeRule)
+        testBody(composeRule)
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -13,6 +13,7 @@ import org.junit.*
 import vn.luongvo.kmm.survey.android.test.CoroutineTestRule
 import vn.luongvo.kmm.survey.android.test.Fake.surveys
 import vn.luongvo.kmm.survey.android.test.Fake.user
+import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.util.DateFormatter
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
 import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
@@ -101,6 +102,15 @@ class HomeViewModelTest {
             awaitItem() shouldBe false
             awaitItem() shouldBe true
             awaitItem() shouldBe false
+        }
+    }
+
+    @Test
+    fun `when clicking on the Next button on each survey, it navigates to the Survey screen`() = runTest {
+        viewModel.navigator.test {
+            viewModel.navigateToSurvey("id")
+
+            expectMostRecentItem() shouldBe AppDestination.Survey
         }
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
@@ -113,7 +113,7 @@ class LoginScreenTest {
                 )
             }
         }
-        testBody.invoke(composeRule)
+        testBody(composeRule)
     }
 
     private fun ComposeContentTestRule.waitForAnimationEnd() {

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreenTest.kt
@@ -1,0 +1,60 @@
+package vn.luongvo.kmm.survey.android.ui.screens.survey
+
+import android.content.Context
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.*
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
+import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
+import vn.luongvo.kmm.survey.domain.usecase.*
+
+@RunWith(AndroidJUnit4::class)
+class SurveyScreenTest {
+
+    @get:Rule
+    val composeRule: ComposeContentTestRule = createComposeRule()
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private var expectedAppDestination: AppDestination? = null
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `when entering the Survey screen, it shows UI correctly`() = initComposable {
+        onNodeWithContentDescription(SurveyBackButton).assertIsDisplayed()
+
+        onNodeWithText("Scarlett Bangkok").assertIsDisplayed()
+        onNodeWithText("We'd love to hear from you!").assertIsDisplayed()
+
+        onNodeWithText(context.getString(R.string.survey_start)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `when clicking on the Back button, it navigates back to the Home screen`() = initComposable {
+        onNodeWithContentDescription(SurveyBackButton).performClick()
+
+        assertEquals(expectedAppDestination, AppDestination.Up)
+    }
+
+    private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
+        composeRule.setContent {
+            ComposeTheme {
+                SurveyScreen(
+                    surveyId = "123",
+                    navigator = { destination -> expectedAppDestination = destination }
+                )
+            }
+        }
+        testBody(composeRule)
+    }
+}


### PR DESCRIPTION
- Close #21

## What happened 👀

- Click on the arrow button on each survey in the survey list to open the Survey Detail screen.
- On the Survey Detail screen:
  - Show the title and description.
  - Use the survey cover image URL as the background image.
  - Show the `Start Survey` button on the bottom right corner.
  - Add UI tests on the Survey screen.

## Insight 📝

- Navigate from the Home screen to the Survey screen by argument `surveyId` https://developer.android.com/jetpack/compose/navigation#nav-with-args.

## Proof Of Work 📹



https://user-images.githubusercontent.com/16315358/210036831-e1549c02-9c69-48f9-91c9-1f88f781ba9b.mp4

