### PR TITLE
[#24] [Android] [UI] As a user, I can see many question types when doing survey feedback

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/BackButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/BackButton.kt
@@ -1,15 +1,13 @@
 package vn.luongvo.kmm.survey.android.ui.common
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -23,22 +21,15 @@ fun BackButton(
     modifier: Modifier,
     onClick: () -> Unit
 ) {
-    Button(
-        onClick = onClick,
+    Image(
+        painter = painterResource(id = R.drawable.ic_arrow_right),
+        contentDescription = null,
+        colorFilter = ColorFilter.tint(White),
+        contentScale = ContentScale.FillWidth,
         modifier = modifier
             .wrapContentSize()
-            .rotate(Rotate180), // switch Right Arrow to Back button
-        contentPadding = PaddingValues(dimensions.paddingMedium),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = Transparent
-        ),
-        elevation = null
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_arrow_right),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(Color.White),
-            contentScale = ContentScale.FillWidth
-        )
-    }
+            .rotate(Rotate180) // switch Right Arrow to Back button
+            .clickable { onClick() }
+            .padding(all = dimensions.paddingMedium)
+    )
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/BackButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/BackButton.kt
@@ -18,8 +18,8 @@ private const val Rotate180 = 180f
 
 @Composable
 fun BackButton(
-    modifier: Modifier,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_arrow_right),

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/CloseButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/CloseButton.kt
@@ -3,35 +3,33 @@ package vn.luongvo.kmm.survey.android.ui.common
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.graphics.Color.Companion.Transparent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import vn.luongvo.kmm.survey.android.R
-import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 
 @Composable
-fun NextCircleButton(
+fun CloseButton(
     onClick: () -> Unit,
     modifier: Modifier
 ) {
     Button(
         onClick = onClick,
-        modifier = modifier.size(dimensions.buttonHeight),
-        shape = CircleShape,
+        modifier = modifier.size(28.dp),
         contentPadding = PaddingValues(0.dp),
         colors = ButtonDefaults.buttonColors(
-            backgroundColor = White
+            backgroundColor = Transparent
         ),
+        elevation = null
     ) {
         Image(
-            painter = painterResource(id = R.drawable.ic_arrow_right),
+            painter = painterResource(id = R.drawable.ic_close),
             contentDescription = null,
             contentScale = ContentScale.FillWidth
         )
@@ -40,8 +38,8 @@ fun NextCircleButton(
 
 @Preview
 @Composable
-fun NextCircleButtonPreview() {
-    NextCircleButton(
+fun CloseButtonPreview() {
+    CloseButton(
         onClick = {},
         modifier = Modifier
     )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/CloseButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/CloseButton.kt
@@ -1,13 +1,12 @@
 package vn.luongvo.kmm.survey.android.ui.common
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,21 +18,15 @@ fun CloseButton(
     onClick: () -> Unit,
     modifier: Modifier
 ) {
-    Button(
-        onClick = onClick,
-        modifier = modifier.size(28.dp),
-        contentPadding = PaddingValues(0.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = Transparent
-        ),
-        elevation = null
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_close),
-            contentDescription = null,
-            contentScale = ContentScale.FillWidth
-        )
-    }
+    Image(
+        painter = painterResource(id = R.drawable.ic_close),
+        contentDescription = null,
+        contentScale = ContentScale.FillWidth,
+        modifier = modifier
+            .size(28.dp)
+            .clip(CircleShape)
+            .clickable { onClick() }
+    )
 }
 
 @Preview

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/CloseButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/CloseButton.kt
@@ -16,7 +16,7 @@ import vn.luongvo.kmm.survey.android.R
 @Composable
 fun CloseButton(
     onClick: () -> Unit,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_close),
@@ -33,7 +33,6 @@ fun CloseButton(
 @Composable
 fun CloseButtonPreview() {
     CloseButton(
-        onClick = {},
-        modifier = Modifier
+        onClick = {}
     )
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/NextCircleButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/NextCircleButton.kt
@@ -1,18 +1,15 @@
 package vn.luongvo.kmm.survey.android.ui.common
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 
@@ -21,21 +18,16 @@ fun NextCircleButton(
     onClick: () -> Unit,
     modifier: Modifier
 ) {
-    Button(
-        onClick = onClick,
-        modifier = modifier.size(dimensions.buttonHeight),
-        shape = CircleShape,
-        contentPadding = PaddingValues(0.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = White
-        ),
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_arrow_right),
-            contentDescription = null,
-            contentScale = ContentScale.FillWidth
-        )
-    }
+    Image(
+        painter = painterResource(id = R.drawable.ic_arrow_right),
+        contentDescription = null,
+        contentScale = ContentScale.Inside,
+        modifier = modifier
+            .size(dimensions.buttonHeight)
+            .clip(CircleShape)
+            .background(White)
+            .clickable { onClick() }
+    )
 }
 
 @Preview

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/NextCircleButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/NextCircleButton.kt
@@ -16,7 +16,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 @Composable
 fun NextCircleButton(
     onClick: () -> Unit,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_arrow_right),
@@ -34,7 +34,6 @@ fun NextCircleButton(
 @Composable
 fun NextCircleButtonPreview() {
     NextCircleButton(
-        onClick = {},
-        modifier = Modifier
+        onClick = {}
     )
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/PrimaryButton.kt
@@ -1,6 +1,7 @@
 package vn.luongvo.kmm.survey.android.ui.common
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,7 +16,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.BlackRussian
 fun PrimaryButton(
     text: String,
     onClick: () -> Unit,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Button(
         shape = shapes.medium,
@@ -39,7 +40,6 @@ fun PrimaryButton(
 fun PrimaryButtonPreview() {
     PrimaryButton(
         text = "Button Text",
-        onClick = {},
-        modifier = Modifier.fillMaxWidth()
+        onClick = {}
     )
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -115,7 +115,7 @@ private fun HomeScreenContent(
                 modifier = Modifier
                     .navigationBarsPadding()
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = dimensions.paddingLargest),
+                    .padding(bottom = dimensions.paddingHuge),
                 onSurveyClick = onSurveyClick
             )
         }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -29,7 +29,7 @@ fun HomeFooter(
     pagerState: PagerState,
     isLoading: Boolean,
     survey: SurveyUiModel?,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     onSurveyClick: (SurveyUiModel?) -> Unit
 ) {
     Column(
@@ -144,8 +144,7 @@ fun HomeFooterPreview(
                 title = "Scarlett Bangkok",
                 description = "We'd love to hear from you!",
                 coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
-            ),
-            modifier = Modifier
+            )
         ) {}
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -89,7 +91,7 @@ private fun HomeFooterContent(
         Spacer(modifier = Modifier.width(dimensions.paddingMedium))
         NextCircleButton(
             onClick = { onSurveyClick(survey) },
-            contentDescription = HomeSurveyDetail
+            modifier = Modifier.semantics { this.contentDescription = HomeSurveyDetail }
         )
     }
 }
@@ -143,7 +145,7 @@ fun HomeFooterPreview(
                 description = "We'd love to hear from you!",
                 coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
             ),
-            modifier = Modifier.wrapContentHeight()
+            modifier = Modifier
         ) {}
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -69,7 +69,7 @@ fun HomeHeaderPreview(
             isLoading = isLoading,
             dateTime = "Monday, JUNE 15",
             avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
-            modifier = Modifier.wrapContentHeight()
+            modifier = Modifier
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -25,7 +25,7 @@ fun HomeHeader(
     isLoading: Boolean,
     dateTime: String,
     avatarUrl: String,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier.padding(horizontal = dimensions.paddingMedium)
@@ -68,8 +68,7 @@ fun HomeHeaderPreview(
         HomeHeader(
             isLoading = isLoading,
             dateTime = "Monday, JUNE 15",
-            avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23",
-            modifier = Modifier
+            avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/QuestionUiModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/QuestionUiModel.kt
@@ -1,0 +1,5 @@
+package vn.luongvo.kmm.survey.android.ui.screens.survey
+
+data class QuestionUiModel(
+    val text: String
+)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -70,13 +70,8 @@ private fun SurveyScreenContent(
                 count = questions.size,
                 question = questions[index - 1],
                 onCloseClick = onBackClick,
-                onNextClick = {
-                    if (index != questions.size) {
-                        pagerState.scrollToNextPage(scope)
-                    } else {
-                        onSubmitClick()
-                    }
-                }
+                onNextClick = { pagerState.scrollToNextPage(scope) },
+                onSubmitClick = onSubmitClick
             )
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -1,26 +1,17 @@
 package vn.luongvo.kmm.survey.android.ui.screens.survey
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.White
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import com.google.accompanist.pager.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
-import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
-import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
-import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
+import vn.luongvo.kmm.survey.android.ui.screens.survey.views.SurveyIntro
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
-import vn.luongvo.kmm.survey.android.ui.theme.White70
 
 const val SurveyBackButton = "SurveyBackButton"
 
@@ -35,69 +26,38 @@ fun SurveyScreen(
     }
 
     SurveyScreenContent(
-        onBackClick = { navigator(AppDestination.Up) },
-        onStartClick = {
-            // TODO start survey
-        }
+        onBackClick = { navigator(AppDestination.Up) }
     )
 }
 
+@OptIn(ExperimentalPagerApi::class)
 @Composable
 private fun SurveyScreenContent(
-    onBackClick: () -> Unit,
-    onStartClick: () -> Unit
+    onBackClick: () -> Unit
 ) {
+    val pagerState = rememberPagerState()
+    val scope = rememberCoroutineScope()
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        DimmedImageBackground(
-            // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-            imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
-        )
-
-        BackButton(
-            modifier = Modifier
-                .statusBarsPadding()
-                .padding(vertical = 5.dp)
-                .semantics { this.contentDescription = SurveyBackButton },
-            onClick = onBackClick
-        )
-
-        Column(
-            modifier = Modifier
-                .statusBarsPadding()
-                .navigationBarsPadding()
-                .fillMaxWidth()
-                .padding(top = 70.dp)
-                .padding(horizontal = dimensions.paddingMedium)
-        ) {
-            Text(
-                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-                text = "Scarlett Bangkok",
-                color = White,
-                style = typography.h4,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            Spacer(modifier = Modifier.height(dimensions.paddingSmall))
-            Text(
-                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-                text = "We'd love to hear from you!",
-                color = White70,
-                style = typography.body1,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            PrimaryButton(
-                text = stringResource(id = R.string.survey_start),
-                onClick = onStartClick,
-                modifier = Modifier
-                    .wrapContentWidth()
-                    .align(Alignment.End)
-                    .padding(bottom = dimensions.paddingLargest)
+        HorizontalPager(
+            count = 5,
+            state = pagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { index ->
+            SurveyIntro(
+                onBackClick = onBackClick,
+                onStartClick = { pagerState.scrollToNextPage(scope) }
             )
         }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+private fun PagerState.scrollToNextPage(scope: CoroutineScope) {
+    scope.launch {
+        animateScrollToPage(currentPage + 1)
     }
 }
 
@@ -106,8 +66,7 @@ private fun SurveyScreenContent(
 fun SurveyScreenPreview() {
     ComposeTheme {
         SurveyScreenContent(
-            onBackClick = {},
-            onStartClick = {}
+            onBackClick = {}
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -54,6 +54,7 @@ private fun SurveyScreenContent(
     HorizontalPager(
         count = questions.size + 1,
         state = pagerState,
+        userScrollEnabled = false,
         modifier = Modifier.fillMaxSize()
     ) { index ->
         // TODO use question.displayType instead

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -34,7 +34,10 @@ fun SurveyScreen(
             QuestionUiModel(text = "Question NPS"),
             QuestionUiModel(text = "Your contact information")
         ),
-        onBackClick = { navigator(AppDestination.Up) }
+        onBackClick = { navigator(AppDestination.Up) },
+        onSubmitClick = {
+            // TODO submit survey
+        }
     )
 }
 
@@ -42,7 +45,8 @@ fun SurveyScreen(
 @Composable
 private fun SurveyScreenContent(
     questions: List<QuestionUiModel>,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onSubmitClick: () -> Unit
 ) {
     val pagerState = rememberPagerState()
     val scope = rememberCoroutineScope()
@@ -64,7 +68,13 @@ private fun SurveyScreenContent(
                 count = questions.size,
                 question = questions[index - 1],
                 onCloseClick = onBackClick,
-                onNextClick = { pagerState.scrollToNextPage(scope) }
+                onNextClick = {
+                    if (index != questions.size) {
+                        pagerState.scrollToNextPage(scope)
+                    } else {
+                        onSubmitClick()
+                    }
+                }
             )
         }
     }
@@ -85,7 +95,8 @@ fun SurveyScreenPreview() {
             questions = listOf(
                 QuestionUiModel(text = "How fulfilled did you feel during this WFH period?")
             ),
-            onBackClick = {}
+            onBackClick = {},
+            onSubmitClick = {}
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -27,6 +27,7 @@ fun SurveyScreen(
     }
 
     SurveyScreenContent(
+        // TODO fake data, implement in https://github.com/luongvo/kmm-survey/pull/69
         questions = listOf(
             QuestionUiModel(text = "How fulfilled did you feel during this WFH period?"),
             QuestionUiModel(text = "How did WFH change your productivity?"),

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -11,6 +11,7 @@ import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.ui.screens.survey.views.SurveyIntro
+import vn.luongvo.kmm.survey.android.ui.screens.survey.views.SurveyQuestion
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
 const val SurveyBackButton = "SurveyBackButton"
@@ -38,17 +39,21 @@ private fun SurveyScreenContent(
     val pagerState = rememberPagerState()
     val scope = rememberCoroutineScope()
 
-    Box(
+    HorizontalPager(
+        count = 5,
+        state = pagerState,
         modifier = Modifier.fillMaxSize()
-    ) {
-        HorizontalPager(
-            count = 5,
-            state = pagerState,
-            modifier = Modifier.fillMaxSize()
-        ) { index ->
+    ) { index ->
+        // TODO use question.displayType instead
+        if (index == 0) {
             SurveyIntro(
                 onBackClick = onBackClick,
                 onStartClick = { pagerState.scrollToNextPage(scope) }
+            )
+        } else {
+            SurveyQuestion(
+                onCloseClick = onBackClick,
+                onNextClick = { pagerState.scrollToNextPage(scope) }
             )
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -27,6 +27,13 @@ fun SurveyScreen(
     }
 
     SurveyScreenContent(
+        questions = listOf(
+            QuestionUiModel(text = "How fulfilled did you feel during this WFH period?"),
+            QuestionUiModel(text = "How did WFH change your productivity?"),
+            QuestionUiModel(text = "I have a separate space to work (room or living room)."),
+            QuestionUiModel(text = "Question NPS"),
+            QuestionUiModel(text = "Your contact information")
+        ),
         onBackClick = { navigator(AppDestination.Up) }
     )
 }
@@ -34,13 +41,14 @@ fun SurveyScreen(
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 private fun SurveyScreenContent(
+    questions: List<QuestionUiModel>,
     onBackClick: () -> Unit
 ) {
     val pagerState = rememberPagerState()
     val scope = rememberCoroutineScope()
 
     HorizontalPager(
-        count = 5,
+        count = questions.size + 1,
         state = pagerState,
         modifier = Modifier.fillMaxSize()
     ) { index ->
@@ -52,6 +60,9 @@ private fun SurveyScreenContent(
             )
         } else {
             SurveyQuestion(
+                index = index,
+                count = questions.size,
+                question = questions[index - 1],
                 onCloseClick = onBackClick,
                 onNextClick = { pagerState.scrollToNextPage(scope) }
             )
@@ -71,6 +82,9 @@ private fun PagerState.scrollToNextPage(scope: CoroutineScope) {
 fun SurveyScreenPreview() {
     ComposeTheme {
         SurveyScreenContent(
+            questions = listOf(
+                QuestionUiModel(text = "How fulfilled did you feel during this WFH period?")
+            ),
             onBackClick = {}
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyIntro.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyIntro.kt
@@ -65,7 +65,7 @@ fun SurveyIntro(
                 modifier = Modifier
                     .wrapContentWidth()
                     .align(Alignment.End)
-                    .padding(bottom = AppTheme.dimensions.paddingLargest)
+                    .padding(bottom = AppTheme.dimensions.paddingHuge)
             )
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyIntro.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyIntro.kt
@@ -1,0 +1,84 @@
+package vn.luongvo.kmm.survey.android.ui.screens.survey.views
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.common.*
+import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyBackButton
+import vn.luongvo.kmm.survey.android.ui.theme.*
+
+@Composable
+fun SurveyIntro(
+    onBackClick: () -> Unit,
+    onStartClick: () -> Unit
+) {
+    DimmedImageBackground(
+        // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+        imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
+    )
+
+    BackButton(
+        modifier = Modifier
+            .statusBarsPadding()
+            .padding(vertical = 5.dp)
+            .semantics { this.contentDescription = SurveyBackButton },
+        onClick = onBackClick
+    )
+
+    Column(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .fillMaxWidth()
+            .padding(top = 70.dp)
+            .padding(horizontal = AppTheme.dimensions.paddingMedium)
+    ) {
+        Text(
+            // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+            text = "Scarlett Bangkok",
+            color = Color.White,
+            style = AppTheme.typography.h4,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.height(AppTheme.dimensions.paddingSmall))
+        Text(
+            // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+            text = "We'd love to hear from you!",
+            color = White70,
+            style = AppTheme.typography.body1,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        PrimaryButton(
+            text = stringResource(id = R.string.survey_start),
+            onClick = onStartClick,
+            modifier = Modifier
+                .wrapContentWidth()
+                .align(Alignment.End)
+                .padding(bottom = AppTheme.dimensions.paddingLargest)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SurveyIntroPreview() {
+    ComposeTheme {
+        SurveyIntro(
+            onBackClick = {},
+            onStartClick = {}
+        )
+    }
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -21,7 +21,8 @@ fun SurveyQuestion(
     count: Int,
     question: QuestionUiModel,
     onCloseClick: () -> Unit,
-    onNextClick: () -> Unit
+    onNextClick: () -> Unit,
+    onSubmitClick: () -> Unit
 ) {
     Box(
         modifier = Modifier.fillMaxSize()
@@ -69,7 +70,7 @@ fun SurveyQuestion(
             } else {
                 PrimaryButton(
                     text = stringResource(id = R.string.survey_submit),
-                    onClick = onNextClick,
+                    onClick = onSubmitClick,
                     modifier = Modifier
                         .wrapContentWidth()
                         .align(Alignment.End)
@@ -89,7 +90,8 @@ fun SurveyQuestionPreview() {
             count = 5,
             question = QuestionUiModel(text = "How fulfilled did you feel during this WFH period?"),
             onCloseClick = {},
-            onNextClick = {}
+            onNextClick = {},
+            onSubmitClick = {}
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -6,20 +6,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.*
-import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyBackButton
 import vn.luongvo.kmm.survey.android.ui.theme.*
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 
 @Composable
-fun SurveyIntro(
-    onBackClick: () -> Unit,
-    onStartClick: () -> Unit
+fun SurveyQuestion(
+    onCloseClick: () -> Unit,
+    onNextClick: () -> Unit
 ) {
     Box(
         modifier = Modifier.fillMaxSize()
@@ -29,12 +25,12 @@ fun SurveyIntro(
             imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
         )
 
-        BackButton(
+        CloseButton(
             modifier = Modifier
                 .statusBarsPadding()
-                .padding(vertical = 5.dp)
-                .semantics { this.contentDescription = SurveyBackButton },
-            onClick = onBackClick
+                .align(Alignment.TopEnd)
+                .padding(vertical = dimensions.paddingMedium, horizontal = dimensions.paddingSmall),
+            onClick = onCloseClick
         )
 
         Column(
@@ -43,29 +39,27 @@ fun SurveyIntro(
                 .navigationBarsPadding()
                 .fillMaxWidth()
                 .padding(top = 70.dp)
-                .padding(horizontal = AppTheme.dimensions.paddingMedium)
+                .padding(horizontal = dimensions.paddingMedium)
         ) {
             Text(
                 // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-                text = "Scarlett Bangkok",
+                text = "1/5",
+                color = White50,
+                style = AppTheme.typography.body2
+            )
+            Spacer(modifier = Modifier.height(dimensions.paddingSmallest))
+            Text(
+                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
+                text = "How fulfilled did you feel during this WFH period?",
                 color = Color.White,
                 style = AppTheme.typography.h4
             )
-            Spacer(modifier = Modifier.height(AppTheme.dimensions.paddingSmall))
-            Text(
-                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-                text = "We'd love to hear from you!",
-                color = White70,
-                style = AppTheme.typography.body1
-            )
             Spacer(modifier = Modifier.weight(1f))
-            PrimaryButton(
-                text = stringResource(id = R.string.survey_start),
-                onClick = onStartClick,
+            NextCircleButton(
+                onClick = onNextClick,
                 modifier = Modifier
-                    .wrapContentWidth()
                     .align(Alignment.End)
-                    .padding(bottom = AppTheme.dimensions.paddingLargest)
+                    .padding(bottom = dimensions.paddingLargest)
             )
         }
     }
@@ -73,11 +67,11 @@ fun SurveyIntro(
 
 @Preview
 @Composable
-fun SurveyIntroPreview() {
+fun SurveyQuestionPreview() {
     ComposeTheme {
-        SurveyIntro(
-            onBackClick = {},
-            onStartClick = {}
+        SurveyQuestion(
+            onCloseClick = {},
+            onNextClick = {}
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -9,11 +9,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import vn.luongvo.kmm.survey.android.ui.common.*
+import vn.luongvo.kmm.survey.android.ui.screens.survey.QuestionUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 
 @Composable
 fun SurveyQuestion(
+    index: Int,
+    count: Int,
+    question: QuestionUiModel,
     onCloseClick: () -> Unit,
     onNextClick: () -> Unit
 ) {
@@ -42,15 +46,13 @@ fun SurveyQuestion(
                 .padding(horizontal = dimensions.paddingMedium)
         ) {
             Text(
-                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-                text = "1/5",
+                text = "$index/$count",
                 color = White50,
                 style = AppTheme.typography.body2
             )
             Spacer(modifier = Modifier.height(dimensions.paddingSmallest))
             Text(
-                // TODO fetch survey detail https://github.com/luongvo/kmm-survey/issues/23
-                text = "How fulfilled did you feel during this WFH period?",
+                text = question.text,
                 color = Color.White,
                 style = AppTheme.typography.h4
             )
@@ -70,6 +72,9 @@ fun SurveyQuestion(
 fun SurveyQuestionPreview() {
     ComposeTheme {
         SurveyQuestion(
+            index = 1,
+            count = 5,
+            question = QuestionUiModel(text = "How fulfilled did you feel during this WFH period?"),
             onCloseClick = {},
             onNextClick = {}
         )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -6,8 +6,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.screens.survey.QuestionUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.*
@@ -57,12 +59,23 @@ fun SurveyQuestion(
                 style = AppTheme.typography.h4
             )
             Spacer(modifier = Modifier.weight(1f))
-            NextCircleButton(
-                onClick = onNextClick,
-                modifier = Modifier
-                    .align(Alignment.End)
-                    .padding(bottom = dimensions.paddingLargest)
-            )
+            if (index != count) {
+                NextCircleButton(
+                    onClick = onNextClick,
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(bottom = dimensions.paddingLargest)
+                )
+            } else {
+                PrimaryButton(
+                    text = stringResource(id = R.string.survey_submit),
+                    onClick = onNextClick,
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .align(Alignment.End)
+                        .padding(bottom = dimensions.paddingLargest)
+                )
+            }
         }
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -53,7 +53,7 @@ fun SurveyQuestion(
                 color = White50,
                 style = AppTheme.typography.body2
             )
-            Spacer(modifier = Modifier.height(dimensions.paddingSmallest))
+            Spacer(modifier = Modifier.height(dimensions.paddingTiny))
             Text(
                 text = question.text,
                 color = Color.White,
@@ -65,7 +65,7 @@ fun SurveyQuestion(
                     onClick = onNextClick,
                     modifier = Modifier
                         .align(Alignment.End)
-                        .padding(bottom = dimensions.paddingLargest)
+                        .padding(bottom = dimensions.paddingHuge)
                 )
             } else {
                 PrimaryButton(
@@ -74,7 +74,7 @@ fun SurveyQuestion(
                     modifier = Modifier
                         .wrapContentWidth()
                         .align(Alignment.End)
-                        .padding(bottom = dimensions.paddingLargest)
+                        .padding(bottom = dimensions.paddingHuge)
                 )
             }
         }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 class AppDimensions {
+    val paddingSmallest: Dp = 8.dp
     val paddingSmall: Dp = 16.dp
     val paddingMedium: Dp = 20.dp
     val paddingLarge: Dp = 24.dp

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppDimensions.kt
@@ -5,11 +5,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 class AppDimensions {
-    val paddingSmallest: Dp = 8.dp
+    val paddingTiny: Dp = 8.dp
     val paddingSmall: Dp = 16.dp
     val paddingMedium: Dp = 20.dp
     val paddingLarge: Dp = 24.dp
-    val paddingLargest: Dp = 36.dp
+    val paddingHuge: Dp = 36.dp
 
     val inputHeight: Dp = 56.dp
     val buttonHeight: Dp = 56.dp

--- a/android/src/main/res/drawable/ic_close.xml
+++ b/android/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+    <path
+        android:fillAlpha="0.2"
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd"
+        android:pathData="M14,28C21.732,28 28,21.732 28,14C28,6.268 21.732,0 14,0C6.268,0 0,6.268 0,14C0,21.732 6.268,28 14,28Z"
+        android:strokeAlpha="0.2" />
+    <path
+        android:fillAlpha="0.92"
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd"
+        android:pathData="M8.855,8.855C8.382,9.329 8.382,10.097 8.855,10.57L12.285,14L8.855,17.43C8.382,17.903 8.382,18.671 8.855,19.145C9.329,19.618 10.097,19.618 10.57,19.145L14,15.715L17.43,19.145C17.903,19.618 18.671,19.618 19.145,19.145C19.618,18.671 19.618,17.903 19.145,17.43L15.715,14L19.145,10.57C19.618,10.097 19.618,9.329 19.145,8.855C18.671,8.382 17.903,8.382 17.43,8.855L14,12.285L10.57,8.855C10.097,8.382 9.329,8.382 8.855,8.855Z" />
+</vector>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="login_password">Password</string>
 
     <string name="survey_start">Start Survey</string>
+    <string name="survey_submit">Submit</string>
 </resources>


### PR DESCRIPTION
- Close #24

## What happened 👀

On the survey form:
- Show the indicator 1/x.
- Show the Close button.
- Show the question title.
- Show the answer in different ways (handled in separate tasks).
- Show the next button as an arrow.

## Insight 📝

- Use `pager` to navigate between `intro` & `question` pages (don't allow the user to swipe between questions).
- Create `SurveyIntro` & `SurveyQuestion` to show different UI for survey screens.

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/210152204-ca1691e6-7732-44c7-8988-f63aa6d7d73e.mp4


