### PR TITLE
[#18] [Backend] As a user, I can logout

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -6,8 +6,7 @@ import kotlinx.coroutines.launch
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.util.DateFormatter
-import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
-import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
+import vn.luongvo.kmm.survey.domain.usecase.*
 import java.util.*
 
 private const val HeaderDateFormat = "EEEE, MMMM d"
@@ -17,6 +16,7 @@ private const val SurveyPageSize = 10
 class HomeViewModel(
     private val getUserProfileUseCase: GetUserProfileUseCase,
     private val getSurveysUseCase: GetSurveysUseCase,
+    private val logOutUseCase: LogOutUseCase,
     private val dateFormatter: DateFormatter
 ) : BaseViewModel() {
 
@@ -56,5 +56,14 @@ class HomeViewModel(
         viewModelScope.launch {
             _navigator.emit(AppDestination.Survey.buildDestination(surveyId))
         }
+    }
+
+    fun logOut() {
+        logOutUseCase()
+            .catch { e -> _error.emit(e) }
+            .onEach {
+                // TODO https://github.com/luongvo/kmm-survey/issues/19
+            }
+            .launchIn(viewModelScope)
     }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -31,6 +31,7 @@ class HomeScreenTest {
 
     private val mockGetUserProfileUseCase: GetUserProfileUseCase = mockk()
     private val mockGetSurveysUseCase: GetSurveysUseCase = mockk()
+    private val mockLogOutUseCase: LogOutUseCase = mockk()
     private val mockDateFormatter: DateFormatter = mockk()
 
     private lateinit var viewModel: HomeViewModel
@@ -40,11 +41,13 @@ class HomeScreenTest {
     fun setup() {
         every { mockGetUserProfileUseCase() } returns flowOf(user)
         every { mockGetSurveysUseCase(any(), any()) } returns flowOf(surveys)
+        every { mockLogOutUseCase() } returns flowOf(Unit)
         every { mockDateFormatter.format(any(), any()) } returns "Thursday, December 29"
 
         viewModel = HomeViewModel(
             mockGetUserProfileUseCase,
             mockGetSurveysUseCase,
+            mockLogOutUseCase,
             mockDateFormatter
         )
     }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -15,8 +15,7 @@ import vn.luongvo.kmm.survey.android.test.Fake.surveys
 import vn.luongvo.kmm.survey.android.test.Fake.user
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.util.DateFormatter
-import vn.luongvo.kmm.survey.domain.usecase.GetSurveysUseCase
-import vn.luongvo.kmm.survey.domain.usecase.GetUserProfileUseCase
+import vn.luongvo.kmm.survey.domain.usecase.*
 
 @ExperimentalCoroutinesApi
 class HomeViewModelTest {
@@ -26,6 +25,7 @@ class HomeViewModelTest {
 
     private val mockGetUserProfileUseCase: GetUserProfileUseCase = mockk()
     private val mockGetSurveysUseCase: GetSurveysUseCase = mockk()
+    private val mockLogOutUseCase: LogOutUseCase = mockk()
     private val mockDateFormatter: DateFormatter = mockk()
 
     private lateinit var viewModel: HomeViewModel
@@ -34,11 +34,13 @@ class HomeViewModelTest {
     fun setUp() {
         every { mockGetUserProfileUseCase() } returns flowOf(user)
         every { mockGetSurveysUseCase(any(), any()) } returns flowOf(surveys)
+        every { mockLogOutUseCase() } returns flowOf(Unit)
         every { mockDateFormatter.format(any(), any()) } returns "Thursday, December 29"
 
         viewModel = HomeViewModel(
             mockGetUserProfileUseCase,
             mockGetSurveysUseCase,
+            mockLogOutUseCase,
             mockDateFormatter
         )
     }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSource.kt
@@ -11,6 +11,8 @@ interface TokenLocalDataSource {
 
     fun saveToken(token: Token)
 
+    fun clear()
+
     val tokenType: String
 
     val accessToken: String
@@ -24,6 +26,10 @@ class TokenLocalDataSourceImpl(private val settings: Settings) : TokenLocalDataS
         settings[TOKEN_TYPE_KEY] = tokenType
         settings[ACCESS_TOKEN_KEY] = accessToken
         settings[REFRESH_TOKEN_KEY] = refreshToken
+    }
+
+    override fun clear() {
+        settings.clear()
     }
 
     override val tokenType: String

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/AuthRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/AuthRemoteDataSource.kt
@@ -1,8 +1,7 @@
 package vn.luongvo.kmm.survey.data.remote.datasource
 
 import vn.luongvo.kmm.survey.data.remote.ApiClient
-import vn.luongvo.kmm.survey.data.remote.model.request.LoginRequestBody
-import vn.luongvo.kmm.survey.data.remote.model.request.RefreshTokenRequestBody
+import vn.luongvo.kmm.survey.data.remote.model.request.*
 import vn.luongvo.kmm.survey.data.remote.model.response.TokenResponse
 
 interface AuthRemoteDataSource {
@@ -10,6 +9,8 @@ interface AuthRemoteDataSource {
     suspend fun logIn(body: LoginRequestBody): TokenResponse
 
     suspend fun refreshToken(body: RefreshTokenRequestBody): TokenResponse
+
+    suspend fun logOut(body: LogoutRequestBody)
 }
 
 class AuthRemoteDataSourceImpl(private val apiClient: ApiClient) : AuthRemoteDataSource {
@@ -24,6 +25,13 @@ class AuthRemoteDataSourceImpl(private val apiClient: ApiClient) : AuthRemoteDat
     override suspend fun refreshToken(body: RefreshTokenRequestBody): TokenResponse {
         return apiClient.post(
             path = "/v1/oauth/token",
+            requestBody = body
+        )
+    }
+
+    override suspend fun logOut(body: LogoutRequestBody) {
+        return apiClient.post(
+            path = "/v1/oauth/revoke",
             requestBody = body
         )
     }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/request/LogoutRequestBody.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/request/LogoutRequestBody.kt
@@ -1,0 +1,15 @@
+package vn.luongvo.kmm.survey.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import vn.luongvo.kmm.survey.BuildKonfig
+
+@Serializable
+data class LogoutRequestBody(
+    @SerialName("token")
+    val accessToken: String,
+    @SerialName("client_id")
+    val clientId: String = BuildKonfig.CLIENT_ID,
+    @SerialName("client_secret")
+    val clientSecret: String = BuildKonfig.CLIENT_SECRET,
+)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
@@ -31,6 +31,10 @@ class AuthRepositoryImpl(
         tokenLocalDataSource.saveToken(token)
     }
 
+    override fun clearToken() {
+        tokenLocalDataSource.clear()
+    }
+
     override val isLoggedIn: Flow<Boolean>
         get() = flowOf(
             tokenLocalDataSource.tokenType.isNotBlank() && tokenLocalDataSource.accessToken.isNotBlank()

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
@@ -5,8 +5,7 @@ import kotlinx.coroutines.flow.flowOf
 import vn.luongvo.kmm.survey.data.extensions.flowTransform
 import vn.luongvo.kmm.survey.data.local.datasource.TokenLocalDataSource
 import vn.luongvo.kmm.survey.data.remote.datasource.AuthRemoteDataSource
-import vn.luongvo.kmm.survey.data.remote.model.request.LoginRequestBody
-import vn.luongvo.kmm.survey.data.remote.model.request.RefreshTokenRequestBody
+import vn.luongvo.kmm.survey.data.remote.model.request.*
 import vn.luongvo.kmm.survey.data.remote.model.response.toToken
 import vn.luongvo.kmm.survey.domain.model.Token
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
@@ -36,4 +35,9 @@ class AuthRepositoryImpl(
         get() = flowOf(
             tokenLocalDataSource.tokenType.isNotBlank() && tokenLocalDataSource.accessToken.isNotBlank()
         )
+
+    override fun logOut(): Flow<Unit> = flowTransform {
+        authRemoteDataSource
+            .logOut(LogoutRequestBody(accessToken = tokenLocalDataSource.accessToken))
+    }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
@@ -12,4 +12,5 @@ val useCaseModule = module {
     singleOf(::RefreshTokenUseCaseImpl) bind RefreshTokenUseCase::class
     singleOf(::GetSurveysUseCaseImpl) bind GetSurveysUseCase::class
     singleOf(::GetSurveyDetailUseCaseImpl) bind GetSurveyDetailUseCase::class
+    singleOf(::LogOutUseCaseImpl) bind LogOutUseCase::class
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
@@ -11,6 +11,8 @@ interface AuthRepository {
 
     fun saveToken(token: Token)
 
+    fun clearToken()
+
     val isLoggedIn: Flow<Boolean>
 
     fun logOut(): Flow<Unit>

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
@@ -12,4 +12,6 @@ interface AuthRepository {
     fun saveToken(token: Token)
 
     val isLoggedIn: Flow<Boolean>
+
+    fun logOut(): Flow<Unit>
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
@@ -1,0 +1,16 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.domain.repository.AuthRepository
+
+interface LogOutUseCase {
+
+    operator fun invoke(): Flow<Unit>
+}
+
+class LogOutUseCaseImpl(private val repository: AuthRepository) : LogOutUseCase {
+
+    override operator fun invoke(): Flow<Unit> {
+        return repository.logOut()
+    }
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
@@ -1,6 +1,7 @@
 package vn.luongvo.kmm.survey.domain.usecase
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 
 interface LogOutUseCase {
@@ -12,5 +13,6 @@ class LogOutUseCaseImpl(private val repository: AuthRepository) : LogOutUseCase 
 
     override operator fun invoke(): Flow<Unit> {
         return repository.logOut()
+            .onEach { repository.clearToken() }
     }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSourceTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSourceTest.kt
@@ -54,4 +54,13 @@ class TokenLocalDataSourceTest {
         dataSource.accessToken shouldBe "accessToken"
         dataSource.refreshToken shouldBe "refreshToken"
     }
+
+    @Test
+    fun `when clearing token data - it clears token data correctly`() = runTest {
+        dataSource.clear()
+
+        verify(mockSettings)
+            .function(mockSettings::clear)
+            .wasInvoked(exactly = 1.time)
+    }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -166,4 +166,13 @@ class AuthRepositoryTest {
             awaitError() shouldBe throwable
         }
     }
+
+    @Test
+    fun `when calling clearToken - it executes the local data source`() = runTest {
+        repository.clearToken()
+
+        verify(mockTokenLocalDataSource)
+            .function(mockTokenLocalDataSource::clear)
+            .wasInvoked(exactly = 1.time)
+    }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -134,4 +134,36 @@ class AuthRepositoryTest {
             awaitComplete()
         }
     }
+
+    @Test
+    fun `when calling logOut successfully - it returns Unit`() = runTest {
+        given(mockAuthRemoteDataSource)
+            .suspendFunction(mockAuthRemoteDataSource::logOut)
+            .whenInvokedWith(any())
+            .thenReturn(Unit)
+        given(mockTokenLocalDataSource)
+            .invocation { mockTokenLocalDataSource.accessToken }
+            .thenReturn("accessToken")
+
+        repository.logOut().test {
+            awaitItem() shouldBe Unit
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling logOut fails - it throws the corresponding error`() = runTest {
+        val throwable = Throwable()
+        given(mockAuthRemoteDataSource)
+            .suspendFunction(mockAuthRemoteDataSource::logOut)
+            .whenInvokedWith(any())
+            .thenThrow(throwable)
+        given(mockTokenLocalDataSource)
+            .invocation { mockTokenLocalDataSource.accessToken }
+            .thenReturn("accessToken")
+
+        repository.logOut().test {
+            awaitError() shouldBe throwable
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCaseTest.kt
@@ -35,6 +35,10 @@ class LogOutUseCaseTest {
             awaitItem() shouldBe Unit
             awaitComplete()
         }
+
+        verify(mockRepository)
+            .function(mockRepository::clearToken)
+            .wasInvoked(exactly = 1.time)
     }
 
     @Test
@@ -50,5 +54,9 @@ class LogOutUseCaseTest {
         useCase().test {
             awaitError() shouldBe throwable
         }
+
+        verify(mockRepository)
+            .function(mockRepository::clearToken)
+            .wasNotInvoked()
     }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCaseTest.kt
@@ -1,0 +1,54 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.domain.repository.AuthRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class LogOutUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(AuthRepository::class)
+
+    private lateinit var useCase: LogOutUseCase
+
+    @BeforeTest
+    fun setUp() {
+        useCase = LogOutUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when calling logOut successfully - it returns Unit`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::logOut)
+            .whenInvoked()
+            .thenReturn(flowOf(Unit))
+
+        useCase().test {
+            awaitItem() shouldBe Unit
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling logOut fails - it throws the corresponding error`() = runTest {
+        val throwable = Throwable()
+        given(mockRepository)
+            .function(mockRepository::logOut)
+            .whenInvoked()
+            .thenReturn(
+                flow { throw throwable }
+            )
+
+        useCase().test {
+            awaitError() shouldBe throwable
+        }
+    }
+}


### PR DESCRIPTION
- Close #18

## What happened 👀

- Implement backend components for logging out API `v1/oauth/revoke`.
- Clear token after logging out.
- Add sample request in `HomeViewModel`.

## Insight 📝

N/A

## Proof Of Work 📹

```
2023-01-03 14:52:54.560 22535-22535/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeRequestLog: REQUEST: https://survey-api.nimblehq.co/api/v1/oauth/revoke
    METHOD: HttpMethod(value=POST)
    COMMON HEADERS
    -> Accept: application/json
    -> Accept-Charset: UTF-8
    CONTENT HEADERS
    -> Content-Length: 194
    -> Content-Type: application/json
    BODY Content-Type: application/json
    BODY START
    {
        "token": "dTSr1x247xz90AcKfInLFyGU0nRJEsqUI9hE8CuawQE",
        "client_id": "6GbE8dhoz519l2N_F99StqoOs6Tcmm1rXgda4q__rIw",
        "client_secret": "_ayfIm7BeUAhx2W1OUqi20fwO3uNxfo1QstyKlFCgHw"
    }
    BODY END
2023-01-03 14:52:54.938 22535-22588/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeResponseLog: RESPONSE: 200 OK
    METHOD: HttpMethod(value=POST)
    FROM: https://survey-api.nimblehq.co/api/v1/oauth/revoke
    COMMON HEADERS
    -> alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
    -> cache-control: max-age=0, private, must-revalidate
    -> cf-cache-status: DYNAMIC
    -> cf-ray: 783a285dfc969fcb-SIN
    -> connection: keep-alive
    -> content-type: application/json; charset=utf-8
    -> date: Tue, 03 Jan 2023 07:52:54 GMT
    -> etag: W/"13045cd5185cc8fb46c5a64c5a84ed33"
    -> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
    -> referrer-policy: strict-origin-when-cross-origin
    -> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=ocQSSdB8x2O83TSnqepGkrPKu8v9Q%2F7HoYblEwn81IWHY%2F6ihRyfuFVmIFpYkpCecuxenuTxZ0yGoc3OHklUdPi3q6cB6OnfmDdRH2Efh1x2jxB9QfFEFMUQzAQNaHbXBSZ9t600l%2Bvyo8ZM69j0rLF%2Bh%2FvC"}],"group":"cf-nel","max_age":604800}
    -> server: cloudflare
    -> strict-transport-security: max-age=31536000; includeSubDomains
    -> transfer-encoding: chunked
    -> vary: Accept-Encoding, Origin
    -> via: 1.1 vegur
    -> x-android-received-millis: 1672732374932
    -> x-android-response-source: NETWORK 200
    -> x-android-selected-protocol: http/1.1
    -> x-android-sent-millis: 1672732374562
    -> x-content-type-options: nosniff
    -> x-download-options: noopen
    -> x-frame-options: SAMEORIGIN
    -> x-permitted-cross-domain-policies: none
    -> x-request-id: ce37e83b-eb9e-4d4c-9016-dc05b1f8216d
    -> x-runtime: 0.011222
    -> x-xss-protection: 1; mode=block
    BODY Content-Type: application/json; charset=utf-8
    BODY START
    {}
    BODY END
```
