### PR TITLE
[#19] [Android] [Integrate] As a user, I can logout when clicking on Logout in the Side menu

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppDestination.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppDestination.kt
@@ -14,6 +14,8 @@ sealed class AppDestination(val route: String = "") {
 
     object Up : AppDestination()
 
+    object Root : AppDestination("root")
+
     object Login : AppDestination("login")
 
     object Home : AppDestination("home")

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.*
 import androidx.navigation.compose.*
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeScreen
-import vn.luongvo.kmm.survey.android.ui.screens.home.HomeViewModel
 import vn.luongvo.kmm.survey.android.ui.screens.login.LoginScreen
 import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyScreen
 
@@ -12,8 +11,6 @@ import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyScreen
 fun AppNavigation(
     navController: NavHostController = rememberNavController(),
     startDestination: String = AppDestination.Login.destination,
-    sharedHomeViewModel: HomeViewModel,
-    onOpenDrawer: () -> Unit = {}
 ) {
     NavHost(
         route = AppDestination.Root.route,
@@ -27,9 +24,7 @@ fun AppNavigation(
         }
         composable(AppDestination.Home) {
             HomeScreen(
-                viewModel = sharedHomeViewModel,
                 navigator = { destination -> navController.navigate(destination) },
-                onOpenDrawer = onOpenDrawer
             )
         }
         composable(AppDestination.Survey) { backStackEntry ->

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
@@ -16,6 +16,7 @@ fun AppNavigation(
     onOpenDrawer: () -> Unit = {}
 ) {
     NavHost(
+        route = AppDestination.Root.route,
         navController = navController,
         startDestination = startDestination
     ) {
@@ -61,8 +62,18 @@ private fun NavHostController.navigate(destination: AppDestination) {
             route = destination.destination,
             navOptions {
                 popUpTo(
-                    route = AppDestination.Login.route
-                ) { inclusive = true }
+                    route = AppDestination.Root.route
+                ) { inclusive = false }
+                launchSingleTop = true
+            }
+        )
+        is AppDestination.Login -> navigate(
+            route = destination.destination,
+            navOptions {
+                popUpTo(
+                    route = AppDestination.Root.route
+                ) { inclusive = false }
+                launchSingleTop = true
             }
         )
         else -> navigate(route = destination.destination)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
@@ -3,7 +3,8 @@ package vn.luongvo.kmm.survey.android.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.*
 import androidx.navigation.compose.*
-import vn.luongvo.kmm.survey.android.ui.screens.home.*
+import vn.luongvo.kmm.survey.android.ui.screens.home.HomeScreen
+import vn.luongvo.kmm.survey.android.ui.screens.home.HomeViewModel
 import vn.luongvo.kmm.survey.android.ui.screens.login.LoginScreen
 import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyScreen
 
@@ -12,7 +13,6 @@ fun AppNavigation(
     navController: NavHostController = rememberNavController(),
     startDestination: String = AppDestination.Login.destination,
     sharedHomeViewModel: HomeViewModel,
-    onDrawerUiStateChange: (UserUiModel?) -> Unit = {},
     onOpenDrawer: () -> Unit = {}
 ) {
     NavHost(
@@ -29,7 +29,6 @@ fun AppNavigation(
             HomeScreen(
                 viewModel = sharedHomeViewModel,
                 navigator = { destination -> navController.navigate(destination) },
-                onDrawerUiStateChange = onDrawerUiStateChange,
                 onOpenDrawer = onOpenDrawer
             )
         }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/navigation/AppNavigation.kt
@@ -3,8 +3,7 @@ package vn.luongvo.kmm.survey.android.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.*
 import androidx.navigation.compose.*
-import vn.luongvo.kmm.survey.android.ui.screens.home.HomeScreen
-import vn.luongvo.kmm.survey.android.ui.screens.home.UserUiModel
+import vn.luongvo.kmm.survey.android.ui.screens.home.*
 import vn.luongvo.kmm.survey.android.ui.screens.login.LoginScreen
 import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyScreen
 
@@ -12,6 +11,7 @@ import vn.luongvo.kmm.survey.android.ui.screens.survey.SurveyScreen
 fun AppNavigation(
     navController: NavHostController = rememberNavController(),
     startDestination: String = AppDestination.Login.destination,
+    sharedHomeViewModel: HomeViewModel,
     onDrawerUiStateChange: (UserUiModel?) -> Unit = {},
     onOpenDrawer: () -> Unit = {}
 ) {
@@ -26,6 +26,7 @@ fun AppNavigation(
         }
         composable(AppDestination.Home) {
             HomeScreen(
+                viewModel = sharedHomeViewModel,
                 navigator = { destination -> navController.navigate(destination) },
                 onDrawerUiStateChange = onDrawerUiStateChange,
                 onOpenDrawer = onOpenDrawer

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/preview/HomeParameterProvider.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/preview/HomeParameterProvider.kt
@@ -1,0 +1,52 @@
+package vn.luongvo.kmm.survey.android.ui.preview
+
+import androidx.compose.material.DrawerValue
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import vn.luongvo.kmm.survey.android.ui.screens.home.SurveyUiModel
+import vn.luongvo.kmm.survey.android.ui.screens.home.UserUiModel
+
+class HomeParameterProvider : PreviewParameterProvider<HomeParameterProvider.Params> {
+
+    private val userUiModel = UserUiModel(
+        email = "luong@nimblehq.co",
+        name = "Luong",
+        avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+    )
+
+    private val surveyUiModels = listOf(
+        SurveyUiModel(
+            id = "1",
+            title = "Scarlett Bangkok",
+            description = "We'd love to hear from you!",
+            coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
+        ),
+        SurveyUiModel(
+            id = "2",
+            title = "ibis Bangkok Riverside",
+            description = "We'd love to hear from you!",
+            coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
+        )
+    )
+
+    override val values = sequenceOf(
+        Params(
+            isLoading = false,
+        ),
+        Params(
+            isLoading = true,
+        ),
+        Params(
+            isLoading = false,
+            drawerState = DrawerValue.Open,
+        )
+    )
+
+    inner class Params(
+        val isLoading: Boolean,
+        val drawerState: DrawerValue = DrawerValue.Closed,
+        val appVersion: String = "v1.0.0",
+        val currentDate: String = "Monday, JUNE 15",
+        val user: UserUiModel = userUiModel,
+        val surveys: List<SurveyUiModel> = surveyUiModels
+    )
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/preview/LoadingParameterProvider.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/preview/LoadingParameterProvider.kt
@@ -1,4 +1,4 @@
-package vn.luongvo.kmm.survey.android.ui.providers
+package vn.luongvo.kmm.survey.android.ui.preview
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainActivity.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
+import vn.luongvo.kmm.survey.android.ui.navigation.AppNavigation
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
 
 class MainActivity : ComponentActivity() {
@@ -14,7 +15,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             ComposeTheme {
-                MainScreen()
+                AppNavigation()
             }
         }
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
@@ -27,6 +29,7 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.colors
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun MainScreen(
     viewModel: HomeViewModel = getViewModel(),
@@ -34,7 +37,7 @@ fun MainScreen(
 ) {
     val drawerState = rememberDrawerState(initialDrawerValue)
     val scope = rememberCoroutineScope()
-    var user by remember { mutableStateOf<UserUiModel?>(null) }
+    val user by viewModel.user.collectAsStateWithLifecycle()
 
     RtlModalDrawer(
         drawerState = drawerState,
@@ -53,9 +56,6 @@ fun MainScreen(
     ) {
         AppNavigation(
             sharedHomeViewModel = viewModel,
-            onDrawerUiStateChange = {
-                user = it
-            },
             onOpenDrawer = {
                 scope.launch {
                     drawerState.open()

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainScreen.kt
@@ -16,13 +16,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
-import timber.log.Timber
+import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.BuildConfig
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.RtlModalDrawer
 import vn.luongvo.kmm.survey.android.ui.navigation.AppNavigation
-import vn.luongvo.kmm.survey.android.ui.screens.home.HomeUserAvatar
-import vn.luongvo.kmm.survey.android.ui.screens.home.UserUiModel
+import vn.luongvo.kmm.survey.android.ui.screens.home.*
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.colors
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
@@ -30,15 +29,11 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 
 @Composable
 fun MainScreen(
+    viewModel: HomeViewModel = getViewModel(),
     initialDrawerValue: DrawerValue = DrawerValue.Closed
 ) {
     val drawerState = rememberDrawerState(initialDrawerValue)
     val scope = rememberCoroutineScope()
-    val openDrawer = {
-        scope.launch {
-            drawerState.open()
-        }
-    }
     var user by remember { mutableStateOf<UserUiModel?>(null) }
 
     RtlModalDrawer(
@@ -48,15 +43,24 @@ fun MainScreen(
             Drawer(
                 user = user,
                 onLogoutClick = {
-                    // TODO https://github.com/luongvo/kmm-survey/issues/19
-                    Timber.d("onLogoutClick")
+                    scope.launch {
+                        drawerState.close()
+                    }
+                    viewModel.logOut()
                 }
             )
         }
     ) {
         AppNavigation(
-            onDrawerUiStateChange = { user = it },
-            onOpenDrawer = { openDrawer() }
+            sharedHomeViewModel = viewModel,
+            onDrawerUiStateChange = {
+                user = it
+            },
+            onOpenDrawer = {
+                scope.launch {
+                    drawerState.open()
+                }
+            }
         )
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/MainScreen.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
-import vn.luongvo.kmm.survey.android.BuildConfig
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.RtlModalDrawer
 import vn.luongvo.kmm.survey.android.ui.navigation.AppNavigation
@@ -38,6 +37,7 @@ fun MainScreen(
     val drawerState = rememberDrawerState(initialDrawerValue)
     val scope = rememberCoroutineScope()
     val user by viewModel.user.collectAsStateWithLifecycle()
+    val appVersion by viewModel.appVersion.collectAsStateWithLifecycle()
 
     RtlModalDrawer(
         drawerState = drawerState,
@@ -45,6 +45,7 @@ fun MainScreen(
         drawerContent = {
             Drawer(
                 user = user,
+                appVersion = appVersion,
                 onLogoutClick = {
                     scope.launch {
                         drawerState.close()
@@ -68,6 +69,7 @@ fun MainScreen(
 @Composable
 private fun Drawer(
     user: UserUiModel?,
+    appVersion: String,
     onLogoutClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -113,7 +115,7 @@ private fun Drawer(
         )
         Spacer(modifier = Modifier.weight(1f))
         Text(
-            text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+            text = appVersion,
             color = White50,
             style = typography.subtitle1.copy(fontSize = 11.sp)
         )
@@ -140,6 +142,7 @@ fun DrawerPreview() {
                 name = "Luong",
                 avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
             ),
+            appVersion = "v1.0.0",
             onLogoutClick = {}
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -175,18 +175,20 @@ private fun HomeScreenContent(
 @Composable
 fun HomeScreenPreview(
     @PreviewParameter(HomeParameterProvider::class) params: HomeParameterProvider.Params
-) = with(params) {
-    ComposeTheme {
-        HomeScreenWithDrawer(
-            appVersion = appVersion,
-            initialDrawerState = drawerState,
-            scaffoldState = rememberScaffoldState(),
-            isLoading = isLoading,
-            currentDate = currentDate,
-            user = user,
-            surveys = surveys,
-            onSurveyClick = {},
-            onMenuLogoutClick = {}
-        )
+) {
+    with(params) {
+        ComposeTheme {
+            HomeScreenWithDrawer(
+                appVersion = appVersion,
+                initialDrawerState = drawerState,
+                scaffoldState = rememberScaffoldState(),
+                isLoading = isLoading,
+                currentDate = currentDate,
+                user = user,
+                surveys = surveys,
+                onSurveyClick = {},
+                onMenuLogoutClick = {}
+            )
+        }
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -16,7 +16,7 @@ import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
 import vn.luongvo.kmm.survey.android.ui.common.RtlModalDrawer
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
-import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
+import vn.luongvo.kmm.survey.android.ui.preview.*
 import vn.luongvo.kmm.survey.android.ui.screens.home.views.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme
@@ -174,33 +174,17 @@ private fun HomeScreenContent(
 @Preview(showSystemUi = true)
 @Composable
 fun HomeScreenPreview(
-    @PreviewParameter(LoadingParameterProvider::class) isLoading: Boolean
-) {
+    @PreviewParameter(HomeParameterProvider::class) params: HomeParameterProvider.Params
+) = with(params) {
     ComposeTheme {
         HomeScreenWithDrawer(
-            appVersion = "v1.0.0",
+            appVersion = appVersion,
+            initialDrawerState = drawerState,
             scaffoldState = rememberScaffoldState(),
             isLoading = isLoading,
-            currentDate = "Monday, JUNE 15",
-            user = UserUiModel(
-                email = "luong@nimblehq.co",
-                name = "Luong",
-                avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
-            ),
-            surveys = listOf(
-                SurveyUiModel(
-                    id = "1",
-                    title = "Scarlett Bangkok",
-                    description = "We'd love to hear from you!",
-                    coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_"
-                ),
-                SurveyUiModel(
-                    id = "2",
-                    title = "ibis Bangkok Riverside",
-                    description = "We'd love to hear from you!",
-                    coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/287db81c5e4242412cc0_"
-                )
-            ),
+            currentDate = currentDate,
+            user = user,
+            surveys = surveys,
             onSurveyClick = {},
             onMenuLogoutClick = {}
         )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.*
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
@@ -39,11 +40,12 @@ fun HomeScreen(
 
     val scaffoldState = rememberScaffoldState()
     val context = LocalContext.current
-    LaunchedEffect(error) {
-        error?.let {
+    val scope = rememberCoroutineScope()
+    error?.let {
+        scope.launch {
             scaffoldState.snackbarHostState.showSnackbar(message = it.userReadableMessage(context))
-            viewModel.clearError()
         }
+        viewModel.clearError()
     }
 
     LaunchedEffect(viewModel.navigator) {

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -29,7 +29,6 @@ const val HomeSurveyDetail = "HomeSurveyDetail"
 fun HomeScreen(
     viewModel: HomeViewModel = getViewModel(),
     navigator: (destination: AppDestination) -> Unit,
-    onDrawerUiStateChange: (UserUiModel?) -> Unit,
     onOpenDrawer: () -> Unit
 ) {
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
@@ -55,8 +54,6 @@ fun HomeScreen(
     LaunchedEffect(Unit) {
         viewModel.init()
     }
-
-    onDrawerUiStateChange(user)
 
     HomeScreenContent(
         scaffoldState = scaffoldState,

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -62,7 +62,7 @@ class HomeViewModel(
         logOutUseCase()
             .catch { e -> _error.emit(e) }
             .onEach {
-                // TODO https://github.com/luongvo/kmm-survey/issues/19
+                _navigator.emit(AppDestination.Login)
             }
             .launchIn(viewModelScope)
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package vn.luongvo.kmm.survey.android.ui.screens.home
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import vn.luongvo.kmm.survey.android.BuildConfig
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.util.DateFormatter
@@ -23,6 +24,9 @@ class HomeViewModel(
     private val _currentDate = MutableStateFlow("")
     val currentDate: StateFlow<String> = _currentDate
 
+    private val _appVersion = MutableStateFlow("")
+    val appVersion: StateFlow<String> = _appVersion
+
     private val _user = MutableStateFlow<UserUiModel?>(null)
     val user: StateFlow<UserUiModel?> = _user
 
@@ -34,6 +38,7 @@ class HomeViewModel(
             _currentDate.emit(
                 dateFormatter.format(Calendar.getInstance().time, HeaderDateFormat)
             )
+            _appVersion.emit("v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
         }
 
         getUserProfileUseCase()

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeDrawer.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeDrawer.kt
@@ -13,10 +13,12 @@ import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.preview.HomeParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.UserUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.colors
@@ -81,15 +83,13 @@ fun HomeDrawer(
 
 @Preview
 @Composable
-fun HomeDrawerPreview() {
+fun HomeDrawerPreview(
+    @PreviewParameter(HomeParameterProvider::class, limit = 1) params: HomeParameterProvider.Params
+) = with(params) {
     ComposeTheme {
         HomeDrawer(
-            user = UserUiModel(
-                email = "luong@nimblehq.co",
-                name = "Luong",
-                avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
-            ),
-            appVersion = "v1.0.0",
+            user = user,
+            appVersion = appVersion,
             onLogoutClick = {}
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeDrawer.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeDrawer.kt
@@ -85,12 +85,14 @@ fun HomeDrawer(
 @Composable
 fun HomeDrawerPreview(
     @PreviewParameter(HomeParameterProvider::class, limit = 1) params: HomeParameterProvider.Params
-) = with(params) {
-    ComposeTheme {
-        HomeDrawer(
-            user = user,
-            appVersion = appVersion,
-            onLogoutClick = {}
-        )
+) {
+    with(params) {
+        ComposeTheme {
+            HomeDrawer(
+                user = user,
+                appVersion = appVersion,
+                onLogoutClick = {}
+            )
+        }
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeDrawer.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeDrawer.kt
@@ -1,11 +1,12 @@
-package vn.luongvo.kmm.survey.android.ui.screens
+package vn.luongvo.kmm.survey.android.ui.screens.home.views
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color.Companion.White
@@ -14,60 +15,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
-import kotlinx.coroutines.launch
-import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.R
-import vn.luongvo.kmm.survey.android.ui.common.RtlModalDrawer
-import vn.luongvo.kmm.survey.android.ui.navigation.AppNavigation
-import vn.luongvo.kmm.survey.android.ui.screens.home.*
+import vn.luongvo.kmm.survey.android.ui.screens.home.UserUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.*
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.colors
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 
-@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
-fun MainScreen(
-    viewModel: HomeViewModel = getViewModel(),
-    initialDrawerValue: DrawerValue = DrawerValue.Closed
-) {
-    val drawerState = rememberDrawerState(initialDrawerValue)
-    val scope = rememberCoroutineScope()
-    val user by viewModel.user.collectAsStateWithLifecycle()
-    val appVersion by viewModel.appVersion.collectAsStateWithLifecycle()
-
-    RtlModalDrawer(
-        drawerState = drawerState,
-        gesturesEnabled = drawerState.isOpen,
-        drawerContent = {
-            Drawer(
-                user = user,
-                appVersion = appVersion,
-                onLogoutClick = {
-                    scope.launch {
-                        drawerState.close()
-                    }
-                    viewModel.logOut()
-                }
-            )
-        }
-    ) {
-        AppNavigation(
-            sharedHomeViewModel = viewModel,
-            onOpenDrawer = {
-                scope.launch {
-                    drawerState.open()
-                }
-            }
-        )
-    }
-}
-
-@Composable
-private fun Drawer(
+fun HomeDrawer(
     user: UserUiModel?,
     appVersion: String,
     onLogoutClick: () -> Unit,
@@ -94,7 +51,7 @@ private fun Drawer(
             )
             AsyncImage(
                 model = user?.avatarUrl.orEmpty(),
-                contentDescription = HomeUserAvatar,
+                contentDescription = null,
                 modifier = Modifier
                     .size(dimensions.avatarSize)
                     .clip(CircleShape)
@@ -124,19 +81,9 @@ private fun Drawer(
 
 @Preview
 @Composable
-fun MainScreenPreview() {
+fun HomeDrawerPreview() {
     ComposeTheme {
-        MainScreen(
-            initialDrawerValue = DrawerValue.Open
-        )
-    }
-}
-
-@Preview
-@Composable
-fun DrawerPreview() {
-    ComposeTheme {
-        Drawer(
+        HomeDrawer(
             user = UserUiModel(
                 email = "luong@nimblehq.co",
                 name = "Luong",

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeFooter.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.*
 import vn.luongvo.kmm.survey.android.extension.placeholder
 import vn.luongvo.kmm.survey.android.ui.common.NextCircleButton
-import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
+import vn.luongvo.kmm.survey.android.ui.preview.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeSurveyDetail
 import vn.luongvo.kmm.survey.android.ui.screens.home.SurveyUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.*

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -67,13 +67,15 @@ fun HomeHeader(
 @Composable
 fun HomeHeaderPreview(
     @PreviewParameter(HomeParameterProvider::class, limit = 2) params: HomeParameterProvider.Params
-) = with(params) {
-    ComposeTheme {
-        HomeHeader(
-            isLoading = isLoading,
-            dateTime = currentDate,
-            user = user,
-            onUserAvatarClick = {}
-        )
+) {
+    with(params) {
+        ComposeTheme {
+            HomeHeader(
+                isLoading = isLoading,
+                dateTime = currentDate,
+                user = user,
+                onUserAvatarClick = {}
+            )
+        }
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/views/HomeHeader.kt
@@ -3,7 +3,7 @@ package vn.luongvo.kmm.survey.android.ui.screens.home.views
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.*
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.extension.placeholder
-import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
+import vn.luongvo.kmm.survey.android.ui.preview.HomeParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.HomeUserAvatar
 import vn.luongvo.kmm.survey.android.ui.screens.home.UserUiModel
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
@@ -66,17 +66,13 @@ fun HomeHeader(
 @Preview
 @Composable
 fun HomeHeaderPreview(
-    @PreviewParameter(LoadingParameterProvider::class) isLoading: Boolean
-) {
+    @PreviewParameter(HomeParameterProvider::class, limit = 2) params: HomeParameterProvider.Params
+) = with(params) {
     ComposeTheme {
         HomeHeader(
             isLoading = isLoading,
-            dateTime = "Monday, JUNE 15",
-            user = UserUiModel(
-                email = "luong@nimblehq.co",
-                name = "Luong",
-                avatarUrl = "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
-            ),
+            dateTime = currentDate,
+            user = user,
             onUserAvatarClick = {}
         )
     }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreen.kt
@@ -28,7 +28,7 @@ import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
-import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
+import vn.luongvo.kmm.survey.android.ui.preview.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
 import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 import vn.luongvo.kmm.survey.android.ui.theme.ComposeTheme

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -39,11 +39,12 @@ fun SurveyScreen(
 
     val scaffoldState = rememberScaffoldState()
     val context = LocalContext.current
-    LaunchedEffect(error) {
-        error?.let {
+    val scope = rememberCoroutineScope()
+    error?.let {
+        scope.launch {
             scaffoldState.snackbarHostState.showSnackbar(message = it.userReadableMessage(context))
-            viewModel.clearError()
         }
+        viewModel.clearError()
     }
 
     LaunchedEffect(Unit) {

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
-import vn.luongvo.kmm.survey.android.ui.providers.LoadingParameterProvider
+import vn.luongvo.kmm.survey.android.ui.preview.LoadingParameterProvider
 import vn.luongvo.kmm.survey.android.ui.screens.home.SurveyUiModel
 import vn.luongvo.kmm.survey.android.ui.screens.survey.views.SurveyIntro
 import vn.luongvo.kmm.survey.android.ui.screens.survey.views.SurveyQuestion

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -115,8 +115,7 @@ class HomeScreenTest {
                     viewModel = viewModel,
                     navigator = { destination ->
                         expectedAppDestination = destination
-                    },
-                    onOpenDrawer = {}
+                    }
                 )
             }
         }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -116,7 +116,6 @@ class HomeScreenTest {
                     navigator = { destination ->
                         expectedAppDestination = destination
                     },
-                    onDrawerUiStateChange = {},
                     onOpenDrawer = {}
                 )
             }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -115,4 +115,24 @@ class HomeViewModelTest {
             expectMostRecentItem() shouldBe AppDestination.Survey
         }
     }
+
+    @Test
+    fun `when logging out successfully, it navigates the user back to the Login screen`() = runTest {
+        viewModel.navigator.test {
+            viewModel.logOut()
+
+            expectMostRecentItem() shouldBe AppDestination.Login
+        }
+    }
+
+    @Test
+    fun `when logging out fails, it shows the corresponding error`() = runTest {
+        val error = Exception()
+        every { mockLogOutUseCase() } returns flow { throw error }
+        viewModel.logOut()
+
+        viewModel.error.test {
+            awaitItem() shouldBe error
+        }
+    }
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -18,6 +18,7 @@ import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.util.DateFormatter
 import vn.luongvo.kmm.survey.domain.usecase.*
 
+@Suppress("TooManyFunctions")
 @ExperimentalCoroutinesApi
 class HomeViewModelTest {
 

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.*
 import org.junit.*
+import vn.luongvo.kmm.survey.android.BuildConfig
 import vn.luongvo.kmm.survey.android.test.CoroutineTestRule
 import vn.luongvo.kmm.survey.android.test.Fake.surveys
 import vn.luongvo.kmm.survey.android.test.Fake.user
@@ -46,11 +47,14 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `when loading Home screen, it shows the current date time`() = runTest {
+    fun `when loading Home screen, it shows the current date & app version`() = runTest {
         viewModel.init()
 
         viewModel.currentDate.test {
             expectMostRecentItem() shouldBe "Thursday, December 29"
+        }
+        viewModel.appVersion.test {
+            expectMostRecentItem() shouldBe "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ koverMerged {
         "*.ComposableSingletons*",              // Jetpack Compose generated
         "*.*\$*Preview\$*",                     // Jetpack Compose Preview functions
         "*.di.*",                               // Koin
-        "*.ui.providers*",                      // Jetpack Compose Preview providers
+        "*.ui.preview.*",                       // Jetpack Compose Preview providers
         "*.*Test",                              // Test files
         "*.*Test*",                             // Test cases
         "*.*Mock",                              // mockative @Mock generated

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,8 +30,9 @@ object Versions {
     const val JUNIT = "4.13.2"
     const val JVM_TARGET = "1.8"
 
-    const val KOIN = "3.2.2"
-    const val KOIN_ANDROID = "3.3.0"
+    const val KOIN = "3.3.2"
+    const val KOIN_ANDROID = "3.3.2"
+    const val KOIN_ANDROIDX_COMPOSE = "3.4.1"
     const val KOTEST = "5.5.4"
     const val KOTLIN = "1.7.20"
     const val KOTLIN_COROUTINES = "1.6.4"
@@ -93,7 +94,7 @@ object Dependencies {
     object Koin {
         const val CORE = "io.insert-koin:koin-core:${Versions.KOIN}"
         const val ANDROID = "io.insert-koin:koin-android:${Versions.KOIN_ANDROID}"
-        const val COMPOSE = "io.insert-koin:koin-androidx-compose:${Versions.KOIN_ANDROID}"
+        const val COMPOSE = "io.insert-koin:koin-androidx-compose:${Versions.KOIN_ANDROIDX_COMPOSE}"
     }
 
     object Ktor {

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
@@ -89,6 +89,11 @@ class ApiClient(
                 contentType(ContentType.Application.Json)
             }
         ).bodyAsText()
+
+        // Ignore JSON:API parsing with Unit response
+        if (Unit is T) {
+            return Unit
+        }
         return JsonApi(json).decodeFromJsonApiString(body)
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/ApiClient.kt
@@ -5,6 +5,7 @@ import io.github.aakira.napier.*
 import io.github.aakira.napier.LogLevel
 import io.ktor.client.*
 import io.ktor.client.engine.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -72,6 +73,13 @@ class ApiClient(
                 }
             }
         }
+    }
+
+    fun clearToken() {
+        httpClient.plugin(Auth).providers
+            .filterIsInstance<BearerAuthProvider>()
+            .firstOrNull()
+            ?.clearToken()
     }
 
     suspend inline fun <reified T> get(path: String): T =

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/UserRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/UserRemoteDataSource.kt
@@ -6,6 +6,8 @@ import vn.luongvo.kmm.survey.data.remote.model.response.UserResponse
 interface UserRemoteDataSource {
 
     suspend fun getUserProfile(): UserResponse
+
+    fun clearClientTokenConfig()
 }
 
 class UserRemoteDataSourceImpl(private val apiClient: ApiClient) : UserRemoteDataSource {
@@ -14,5 +16,9 @@ class UserRemoteDataSourceImpl(private val apiClient: ApiClient) : UserRemoteDat
         return apiClient.get(
             path = "/v1/me"
         )
+    }
+
+    override fun clearClientTokenConfig() {
+        apiClient.clearToken()
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryImpl.kt
@@ -31,7 +31,7 @@ class AuthRepositoryImpl(
         tokenLocalDataSource.saveToken(token)
     }
 
-    override fun clearToken() {
+    override fun clearLocalToken() {
         tokenLocalDataSource.clear()
     }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryImpl.kt
@@ -16,4 +16,8 @@ class UserRepositoryImpl(
             .getUserProfile()
             .toUser()
     }
+
+    override fun clearClientTokenConfig() {
+        userRemoteDataSource.clearClientTokenConfig()
+    }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
@@ -11,7 +11,7 @@ interface AuthRepository {
 
     fun saveToken(token: Token)
 
-    fun clearToken()
+    fun clearLocalToken()
 
     val isLoggedIn: Flow<Boolean>
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/UserRepository.kt
@@ -6,4 +6,6 @@ import vn.luongvo.kmm.survey.domain.model.User
 interface UserRepository {
 
     fun getUserProfile(): Flow<User>
+
+    fun clearClientTokenConfig()
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
@@ -1,7 +1,6 @@
 package vn.luongvo.kmm.survey.domain.usecase
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.*
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 
 interface LogOutUseCase {
@@ -13,6 +12,10 @@ class LogOutUseCaseImpl(private val repository: AuthRepository) : LogOutUseCase 
 
     override operator fun invoke(): Flow<Unit> {
         return repository.logOut()
+            .catch {
+                // On error resume next
+                emit(Unit)
+            }
             .onEach { repository.clearToken() }
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
@@ -2,20 +2,27 @@ package vn.luongvo.kmm.survey.domain.usecase
 
 import kotlinx.coroutines.flow.*
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
+import vn.luongvo.kmm.survey.domain.repository.UserRepository
 
 interface LogOutUseCase {
 
     operator fun invoke(): Flow<Unit>
 }
 
-class LogOutUseCaseImpl(private val repository: AuthRepository) : LogOutUseCase {
+class LogOutUseCaseImpl(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository
+) : LogOutUseCase {
 
     override operator fun invoke(): Flow<Unit> {
-        return repository.logOut()
+        return authRepository.logOut()
             .catch {
                 // On error resume next
                 emit(Unit)
             }
-            .onEach { repository.clearToken() }
+            .onEach {
+                authRepository.clearLocalToken()
+                userRepository.clearClientTokenConfig()
+            }
     }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -85,7 +85,7 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `when saving token - it executes the local data source`() = runTest {
+    fun `when saving token - it executes saveToken in the local data source`() = runTest {
         repository.saveToken(token)
         verify(mockTokenLocalDataSource)
             .function(mockTokenLocalDataSource::saveToken)
@@ -168,8 +168,8 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `when calling clearToken - it executes the local data source`() = runTest {
-        repository.clearToken()
+    fun `when calling clearLocalToken - it executes clearToken in the local data source`() = runTest {
+        repository.clearLocalToken()
 
         verify(mockTokenLocalDataSource)
             .function(mockTokenLocalDataSource::clear)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -13,6 +13,7 @@ import vn.luongvo.kmm.survey.test.Fake.tokenResponse
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
+@Suppress("TooManyFunctions")
 @ExperimentalCoroutinesApi
 class AuthRepositoryTest {
 

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/AuthRepositoryTest.kt
@@ -85,7 +85,7 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `when saving token - it executes saveToken in the local data source`() = runTest {
+    fun `when saving token - it executes saveToken method in the local data source`() = runTest {
         repository.saveToken(token)
         verify(mockTokenLocalDataSource)
             .function(mockTokenLocalDataSource::saveToken)
@@ -168,7 +168,7 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `when calling clearLocalToken - it executes clearToken in the local data source`() = runTest {
+    fun `when calling clearLocalToken - it executes clear method in the local data source`() = runTest {
         repository.clearLocalToken()
 
         verify(mockTokenLocalDataSource)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
@@ -54,11 +54,12 @@ class UserRepositoryTest {
     }
 
     @Test
-    fun `when calling clearClientTokenConfig - it executes clearClientTokenConfig in the user data source`() = runTest {
-        repository.clearClientTokenConfig()
+    fun `when calling clearClientTokenConfig - it executes clearClientTokenConfig method in the user data source`() =
+        runTest {
+            repository.clearClientTokenConfig()
 
-        verify(mockDataSource)
-            .function(mockDataSource::clearClientTokenConfig)
-            .wasInvoked(exactly = 1.time)
-    }
+            verify(mockDataSource)
+                .function(mockDataSource::clearClientTokenConfig)
+                .wasInvoked(exactly = 1.time)
+        }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/UserRepositoryTest.kt
@@ -52,4 +52,13 @@ class UserRepositoryTest {
             awaitError() shouldBe throwable
         }
     }
+
+    @Test
+    fun `when calling clearClientTokenConfig - it executes clearClientTokenConfig in the user data source`() = runTest {
+        repository.clearClientTokenConfig()
+
+        verify(mockDataSource)
+            .function(mockDataSource::clearClientTokenConfig)
+            .wasInvoked(exactly = 1.time)
+    }
 }


### PR DESCRIPTION
- Close #19

## What happened 👀

- Integrate to log the user out of the app by clearing all tokens and navigating the user back to the Login page.
- Fix: 
  - we need to ignore `JSON:API` parsing with Unit response by checking generic type `T` with Unit.
  - we need to skip error handling from the logout API and continue logging out. Ideally, if there is any error from the logout API, we will ignore it and continue pushing the user out of the app session.
  - Use CoroutineScope to show snack bar instead of a LaunchedEffect.

## Insight 📝

- ~To ease the Logout API request's execution and its necessary logic, we can **share the `HomeViewModel` for both MainScreen & HomeScreen**. To share the VM for both screens, because the MainScreen is initialized first, we can inject and send the shared HomeViewModel instance to HomeScreen through the NavGraph 🤓 .~
- ~Sharing HomeViewModel helps us get rid of passing the `user` info from HomeScreen down to MainScreen by using `val user by viewModel.user.collectAsStateWithLifecycle()` directly in MainScreen ✅ .~
- 👉 `Move Drawer into HomeScreen instead on MainScreen with AppNavigation instead`.
- Ktor executes the bearer token config 1 time and keeps it alive with the app session. We need to call `clearToken` in authenticated `ApiClient` instance (from `UserRemoteDataSource` or `SurveyRemoteDataSource`) to actually reset the config after clearing the local token cache https://stackoverflow.com/questions/69991824/how-to-clear-bearer-tokens-in-ktor-client-for-android.

## Proof Of Work 📹



https://user-images.githubusercontent.com/16315358/210525181-3ce86102-cb15-4023-9b7c-85f2102fe377.mp4

