### PR TITLE
[#33] [Backend] As a user, I can submit answers for the survey

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/QuestionUiModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/QuestionUiModel.kt
@@ -1,13 +1,19 @@
 package vn.luongvo.kmm.survey.android.ui.screens.survey
 
+import vn.luongvo.kmm.survey.domain.model.Answer
 import vn.luongvo.kmm.survey.domain.model.Question
 
 data class QuestionUiModel(
+    val id: String,
     val text: String,
-    val coverImageUrl: String
+    val coverImageUrl: String,
+    // TODO integrate ui model in https://github.com/luongvo/kmm-survey/issues/34
+    val answers: List<Answer>?
 )
 
 fun Question.toUiModel() = QuestionUiModel(
+    id = id,
     text = text.orEmpty(),
-    coverImageUrl = coverImageUrl.orEmpty() + "l"
+    coverImageUrl = coverImageUrl.orEmpty() + "l",
+    answers = answers
 )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -56,9 +56,7 @@ fun SurveyScreen(
         isLoading = isLoading,
         survey = survey,
         onBackClick = { navigator(AppDestination.Up) },
-        onSubmitClick = {
-            // TODO submit survey
-        }
+        onSubmitClick = { viewModel.submitSurvey() }
     )
 }
 
@@ -86,6 +84,7 @@ private fun SurveyScreenContent(
                     .padding(padding)
             ) { index ->
                 // TODO use question.displayType instead
+                val questionCount = questions.size - 1
                 if (index == 0) {
                     SurveyIntro(
                         survey = survey,
@@ -95,7 +94,7 @@ private fun SurveyScreenContent(
                 } else {
                     SurveyQuestion(
                         index = index,
-                        count = questions.size - 1,
+                        count = questionCount,
                         question = questions[index],
                         onCloseClick = onBackClick,
                         onNextClick = { pagerState.scrollToNextPage(scope) },
@@ -137,8 +136,10 @@ fun SurveyScreenPreview(
                 coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_",
                 questions = listOf(
                     QuestionUiModel(
+                        id = "1",
                         text = "How fulfilled did you feel during this WFH period?",
-                        coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
+                        coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l",
+                        answers = null
                     )
                 )
             ),

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyViewModel.kt
@@ -5,10 +5,13 @@ import kotlinx.coroutines.flow.*
 import vn.luongvo.kmm.survey.android.ui.base.BaseViewModel
 import vn.luongvo.kmm.survey.android.ui.screens.home.SurveyUiModel
 import vn.luongvo.kmm.survey.android.ui.screens.home.toUiModel
+import vn.luongvo.kmm.survey.domain.model.*
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveyDetailUseCase
+import vn.luongvo.kmm.survey.domain.usecase.SubmitSurveyUseCase
 
 class SurveyViewModel(
-    private val getSurveyDetailUseCase: GetSurveyDetailUseCase
+    private val getSurveyDetailUseCase: GetSurveyDetailUseCase,
+    private val submitSurveyUseCase: SubmitSurveyUseCase
 ) : BaseViewModel() {
 
     private val _survey = MutableStateFlow<SurveyUiModel?>(null)
@@ -22,5 +25,33 @@ class SurveyViewModel(
                 _survey.emit(survey.toUiModel())
             }
             .launchIn(viewModelScope)
+    }
+
+    fun submitSurvey() {
+        _survey.value?.let { survey ->
+            // TODO integrate in https://github.com/luongvo/kmm-survey/issues/34
+            val surveySubmission = SurveySubmission(
+                id = survey.id,
+                questions = listOf(
+                    QuestionSubmission(
+                        id = survey.questions[1].id,
+                        answers = listOf(
+                            AnswerSubmission(
+                                id = survey.questions[1].answers?.get(0)?.id.orEmpty(),
+                                answer = "answer"
+                            )
+                        )
+                    )
+                )
+            )
+
+            submitSurveyUseCase(surveySubmission)
+                .injectLoading()
+                .catch { e -> _error.emit(e) }
+                .onEach {
+                    // TODO navigate to the Completion screen
+                }
+                .launchIn(viewModelScope)
+        }
     }
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -92,8 +92,10 @@ fun SurveyQuestionPreview() {
             index = 1,
             count = 5,
             question = QuestionUiModel(
+                id = "1",
                 text = "How fulfilled did you feel during this WFH period?",
-                coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
+                coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l",
+                answers = null
             ),
             onCloseClick = {},
             onNextClick = {},

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreenTest.kt
@@ -29,6 +29,7 @@ class SurveyScreenTest {
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
     private val mockGetSurveyDetailUseCase: GetSurveyDetailUseCase = mockk()
+    private val mockSubmitSurveyUseCase: SubmitSurveyUseCase = mockk()
 
     private lateinit var viewModel: SurveyViewModel
     private var expectedAppDestination: AppDestination? = null
@@ -36,9 +37,11 @@ class SurveyScreenTest {
     @Before
     fun setup() {
         every { mockGetSurveyDetailUseCase(any()) } returns flowOf(surveyDetail)
+        every { mockSubmitSurveyUseCase(any()) } returns flowOf(Unit)
 
         viewModel = SurveyViewModel(
-            mockGetSurveyDetailUseCase
+            mockGetSurveyDetailUseCase,
+            mockSubmitSurveyUseCase
         )
     }
 

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyViewModelTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyViewModelTest.kt
@@ -14,6 +14,7 @@ import vn.luongvo.kmm.survey.android.test.CoroutineTestRule
 import vn.luongvo.kmm.survey.android.test.Fake.surveyDetail
 import vn.luongvo.kmm.survey.android.ui.screens.home.toUiModel
 import vn.luongvo.kmm.survey.domain.usecase.GetSurveyDetailUseCase
+import vn.luongvo.kmm.survey.domain.usecase.SubmitSurveyUseCase
 
 @ExperimentalCoroutinesApi
 class SurveyViewModelTest {
@@ -22,15 +23,18 @@ class SurveyViewModelTest {
     val coroutinesRule = CoroutineTestRule()
 
     private val mockGetSurveyDetailUseCase: GetSurveyDetailUseCase = mockk()
+    private val mockSubmitSurveyUseCase: SubmitSurveyUseCase = mockk()
 
     private lateinit var viewModel: SurveyViewModel
 
     @Before
     fun setUp() {
         every { mockGetSurveyDetailUseCase(any()) } returns flowOf(surveyDetail)
+        every { mockSubmitSurveyUseCase(any()) } returns flowOf(Unit)
 
         viewModel = SurveyViewModel(
-            mockGetSurveyDetailUseCase
+            mockGetSurveyDetailUseCase,
+            mockSubmitSurveyUseCase
         )
     }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/SurveyRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/SurveyRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package vn.luongvo.kmm.survey.data.remote.datasource
 
 import vn.luongvo.kmm.survey.data.remote.ApiClient
+import vn.luongvo.kmm.survey.data.remote.model.request.SurveySubmissionRequestBody
 import vn.luongvo.kmm.survey.data.remote.model.response.SurveyResponse
 
 interface SurveyRemoteDataSource {
@@ -8,6 +9,8 @@ interface SurveyRemoteDataSource {
     suspend fun getSurveys(pageNumber: Int, pageSize: Int): List<SurveyResponse>
 
     suspend fun getSurveyDetail(id: String): SurveyResponse
+
+    suspend fun submitSurvey(body: SurveySubmissionRequestBody)
 }
 
 class SurveyRemoteDataSourceImpl(private val apiClient: ApiClient) : SurveyRemoteDataSource {
@@ -21,6 +24,13 @@ class SurveyRemoteDataSourceImpl(private val apiClient: ApiClient) : SurveyRemot
     override suspend fun getSurveyDetail(id: String): SurveyResponse {
         return apiClient.get(
             path = "/v1/surveys/$id"
+        )
+    }
+
+    override suspend fun submitSurvey(body: SurveySubmissionRequestBody) {
+        return apiClient.post(
+            path = "/v1/responses",
+            requestBody = body
         )
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/request/SurveySubmissionRequestBody.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/model/request/SurveySubmissionRequestBody.kt
@@ -1,0 +1,53 @@
+package vn.luongvo.kmm.survey.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import vn.luongvo.kmm.survey.domain.model.*
+
+@Serializable
+data class SurveySubmissionRequestBody(
+    @SerialName("survey_id")
+    val surveyId: String,
+    @SerialName("questions")
+    val questions: List<QuestionSubmissionRequestBody>
+) {
+
+    companion object {
+        fun build(surveySubmission: SurveySubmission) = SurveySubmissionRequestBody(
+            surveySubmission.id,
+            surveySubmission.questions.map(QuestionSubmissionRequestBody::build)
+        )
+    }
+}
+
+@Serializable
+data class QuestionSubmissionRequestBody(
+    @SerialName("id")
+    val id: String,
+    @SerialName("answers")
+    val answers: List<AnswerSubmissionRequestBody>
+) {
+
+    companion object {
+        fun build(questionSubmission: QuestionSubmission) = QuestionSubmissionRequestBody(
+            questionSubmission.id,
+            questionSubmission.answers.map(AnswerSubmissionRequestBody::build)
+        )
+    }
+}
+
+@Serializable
+data class AnswerSubmissionRequestBody(
+    @SerialName("id")
+    val id: String,
+    @SerialName("answer")
+    val answer: String?
+) {
+
+    companion object {
+        fun build(answerSubmission: AnswerSubmission) = AnswerSubmissionRequestBody(
+            answerSubmission.id,
+            answerSubmission.answer
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -3,8 +3,10 @@ package vn.luongvo.kmm.survey.data.repository
 import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.data.extensions.flowTransform
 import vn.luongvo.kmm.survey.data.remote.datasource.SurveyRemoteDataSource
+import vn.luongvo.kmm.survey.data.remote.model.request.SurveySubmissionRequestBody
 import vn.luongvo.kmm.survey.data.remote.model.response.toSurvey
 import vn.luongvo.kmm.survey.domain.model.Survey
+import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 class SurveyRepositoryImpl(
@@ -21,5 +23,10 @@ class SurveyRepositoryImpl(
         surveyRemoteDataSource
             .getSurveyDetail(id = id)
             .toSurvey()
+    }
+
+    override fun submitSurvey(submission: SurveySubmission): Flow<Unit> = flowTransform {
+        surveyRemoteDataSource
+            .submitSurvey(SurveySubmissionRequestBody.build(submission))
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
@@ -13,4 +13,5 @@ val useCaseModule = module {
     singleOf(::GetSurveysUseCaseImpl) bind GetSurveysUseCase::class
     singleOf(::GetSurveyDetailUseCaseImpl) bind GetSurveyDetailUseCase::class
     singleOf(::LogOutUseCaseImpl) bind LogOutUseCase::class
+    singleOf(::SubmitSurveyUseCaseImpl) bind SubmitSurveyUseCase::class
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/model/SurveySubmission.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/model/SurveySubmission.kt
@@ -1,0 +1,16 @@
+package vn.luongvo.kmm.survey.domain.model
+
+data class SurveySubmission(
+    val id: String,
+    val questions: List<QuestionSubmission>
+)
+
+data class QuestionSubmission(
+    val id: String,
+    val answers: List<AnswerSubmission>
+)
+
+data class AnswerSubmission(
+    val id: String,
+    val answer: String? = null
+)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
@@ -2,10 +2,13 @@ package vn.luongvo.kmm.survey.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.domain.model.Survey
+import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 
 interface SurveyRepository {
 
     fun getSurveys(pageNumber: Int, pageSize: Int): Flow<List<Survey>>
 
     fun getSurveyDetail(id: String): Flow<Survey>
+
+    fun submitSurvey(submission: SurveySubmission): Flow<Unit>
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/SubmitSurveyUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/SubmitSurveyUseCase.kt
@@ -1,0 +1,17 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.domain.model.SurveySubmission
+import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
+
+interface SubmitSurveyUseCase {
+
+    operator fun invoke(submission: SurveySubmission): Flow<Unit>
+}
+
+class SubmitSurveyUseCaseImpl(private val repository: SurveyRepository) : SubmitSurveyUseCase {
+
+    override operator fun invoke(submission: SurveySubmission): Flow<Unit> {
+        return repository.submitSurvey(submission)
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.mockative.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import vn.luongvo.kmm.survey.data.remote.datasource.SurveyRemoteDataSource
+import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 import vn.luongvo.kmm.survey.test.Fake.surveyDetail
 import vn.luongvo.kmm.survey.test.Fake.surveyDetailResponse
@@ -79,6 +80,42 @@ class SurveyRepositoryTest {
             .thenThrow(throwable)
 
         repository.getSurveyDetail(id = "id").test {
+            awaitError() shouldBe throwable
+        }
+    }
+
+    @Test
+    fun `when calling submitSurvey successfully - it returns Unit`() = runTest {
+        given(mockDataSource)
+            .suspendFunction(mockDataSource::submitSurvey)
+            .whenInvokedWith(any())
+            .thenReturn(Unit)
+
+        repository.submitSurvey(
+            submission = SurveySubmission(
+                id = "id",
+                questions = emptyList()
+            )
+        ).test {
+            awaitItem() shouldBe Unit
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling submitSurvey fails - it throws the corresponding error`() = runTest {
+        val throwable = Throwable()
+        given(mockDataSource)
+            .suspendFunction(mockDataSource::submitSurvey)
+            .whenInvokedWith(any())
+            .thenThrow(throwable)
+
+        repository.submitSurvey(
+            submission = SurveySubmission(
+                id = "id",
+                questions = emptyList()
+            )
+        ).test {
             awaitError() shouldBe throwable
         }
     }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/SubmitSurveyUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/SubmitSurveyUseCaseTest.kt
@@ -1,0 +1,65 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.domain.model.SurveySubmission
+import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class SubmitSurveyUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(SurveyRepository::class)
+
+    private lateinit var useCase: SubmitSurveyUseCase
+
+    @BeforeTest
+    fun setUp() {
+        useCase = SubmitSurveyUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when calling submitSurvey successfully - it returns Unit`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::submitSurvey)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(Unit))
+
+        useCase(
+            submission = SurveySubmission(
+                id = "id",
+                questions = emptyList()
+            )
+        ).test {
+            awaitItem() shouldBe Unit
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling submitSurvey fails - it throws the corresponding error`() = runTest {
+        val throwable = Throwable()
+        given(mockRepository)
+            .function(mockRepository::submitSurvey)
+            .whenInvokedWith(any())
+            .thenReturn(
+                flow { throw throwable }
+            )
+
+        useCase(
+            submission = SurveySubmission(
+                id = "id",
+                questions = emptyList()
+            )
+        ).test {
+            awaitError() shouldBe throwable
+        }
+    }
+}


### PR DESCRIPTION
- Close #33

## What happened 👀

- Implement backend components for submitting survey responses API `/v1/responses`.
- Add sample request in `SurveyViewModel`.

## Insight 📝

Fake model for sample API request

```
            val surveySubmission = SurveySubmission(
                id = survey.id,
                questions = listOf(
                    QuestionSubmission(
                        id = survey.questions[1].id,
                        answers = listOf(
                            AnswerSubmission(
                                id = survey.questions[1].answers?.get(0)?.id.orEmpty(),
                                answer = "answer"
                            )
                        )
                    )
                )
            )
```

## Proof Of Work 📹

```
2023-01-05 14:34:20.555 23027-23027/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeRequestLog: REQUEST: https://survey-api.nimblehq.co/api/v1/responses
    METHOD: HttpMethod(value=POST)
    COMMON HEADERS
    -> Accept: application/json
    -> Accept-Charset: UTF-8
    -> Authorization: Bearer 5nAy-saabomEZM3_BNirm1rUpI88WN9-iudyGABxaoU
    CONTENT HEADERS
    -> Content-Length: 295
    -> Content-Type: application/json
    BODY Content-Type: application/json
    BODY START
    {
        "survey_id": "d5de6a8f8f5f1cfe51bc",
        "questions": [
            {
                "id": "940d229e4cd87cd1e202",
                "answers": [
                    {
                        "id": "4cbc3e5a1c87d99bc7ee",
                        "answer": "answer"
                    }
                ]
            }
        ]
    }
    BODY END
2023-01-05 14:34:20.936 23027-23075/vn.luongvo.kmm.survey.android.staging D/HttpClientCallLogger$closeResponseLog: RESPONSE: 201 Created
    METHOD: HttpMethod(value=POST)
    FROM: https://survey-api.nimblehq.co/api/v1/responses
    COMMON HEADERS
    -> alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
    -> cache-control: max-age=0, private, must-revalidate
    -> cf-cache-status: DYNAMIC
    -> cf-ray: 784a87e9fcf10796-HKG
    -> connection: keep-alive
    -> content-type: application/json; charset=utf-8
    -> date: Thu, 05 Jan 2023 07:34:20 GMT
    -> etag: W/"3e257828e76751314bd867ec78ba5616"
    -> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
    -> referrer-policy: strict-origin-when-cross-origin
    -> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=sZ5kmfCGESuVQecPrXaoLGzvrFqu6t95OBAoMGoFFJ09P4DPX%2BJqXwUOY4kb8IQqVX%2BpcPXQujGo%2FSfFjQr602ws%2Fvs7ef6mU735NfDR5rh3C53Cl0J%2FRpKGXNUNw9Pt2yTgzNfT3oXN"}],"group":"cf-nel","max_age":604800}
    -> server: cloudflare
    -> strict-transport-security: max-age=31536000; includeSubDomains
    -> transfer-encoding: chunked
    -> vary: Accept-Encoding, Origin
    -> via: 1.1 vegur
    -> x-android-received-millis: 1672904060928
    -> x-android-response-source: NETWORK 201
    -> x-android-selected-protocol: http/1.1
    -> x-android-sent-millis: 1672904060557
    -> x-content-type-options: nosniff
    -> x-download-options: noopen
    -> x-frame-options: SAMEORIGIN
    -> x-permitted-cross-domain-policies: none
    -> x-request-id: 0414fd3b-da1f-4247-9f36-092787f90dc0
    -> x-runtime: 0.004351
    -> x-xss-protection: 1; mode=block
    BODY Content-Type: application/json; charset=utf-8
    BODY START
    {}
    BODY END
```
