### PR TITLE
[#32] [Android] [UI] As a user, I can see many question types: smiley rating

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/RatingBar.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/RatingBar.kt
@@ -58,9 +58,9 @@ fun HeartRatingBar(
 
 @Composable
 fun SmileyRatingBar(
-    modifier: Modifier = Modifier,
     answers: List<AnswerUiModel>,
     onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val emojis = listOf(
         EMOJI_RED_ANGRY_FACE,
@@ -82,16 +82,19 @@ fun SmileyRatingBar(
 private fun RatingBar(
     emojis: List<String>,
     answers: List<AnswerUiModel>,
-    isSingleSelection: Boolean = false,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    isSingleSelection: Boolean = false,
 ) {
     var selectedIndex by remember { mutableStateOf(-1) }
     LazyRow(
         modifier = modifier
     ) {
         items(emojis.size) { index ->
-            val isSelected = if (isSingleSelection) index == selectedIndex else index <= selectedIndex
+            val isSelected = if (isSingleSelection)
+                index == selectedIndex
+            else
+                index <= selectedIndex
             val alpha = if (isSelected) EMOJI_ALPHA_SELECTED else EMOJI_ALPHA_UNSELECTED
             Button(
                 onClick = {

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/RatingBar.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/RatingBar.kt
@@ -17,6 +17,11 @@ import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
 
 private const val EMOJI_STAR = "⭐️️"
 private const val EMOJI_HEART = "❤️"
+private const val EMOJI_RED_ANGRY_FACE = "\uD83D\uDE21" // 😡
+private const val EMOJI_CONFUSED_FACE = "\uD83D\uDE15" // 😕
+private const val EMOJI_NEUTRAL_FACE = "\uD83D\uDE10" // 😐
+private const val EMOJI_SLIGHTLY_SMILING_FACE = "\uD83D\uDE42" // 🙂
+private const val EMOJI_GRINNING_FACE_WITH_SMILING_EYES = "\uD83D\uDE04" // 😄
 
 private const val EMOJI_ALPHA_SELECTED = 1f
 private const val EMOJI_ALPHA_UNSELECTED = 0.5f
@@ -52,9 +57,32 @@ fun HeartRatingBar(
 }
 
 @Composable
+fun SmileyRatingBar(
+    modifier: Modifier = Modifier,
+    answers: List<AnswerUiModel>,
+    onValueChange: (String) -> Unit,
+) {
+    val emojis = listOf(
+        EMOJI_RED_ANGRY_FACE,
+        EMOJI_CONFUSED_FACE,
+        EMOJI_NEUTRAL_FACE,
+        EMOJI_SLIGHTLY_SMILING_FACE,
+        EMOJI_GRINNING_FACE_WITH_SMILING_EYES
+    )
+    RatingBar(
+        modifier = modifier,
+        emojis = emojis,
+        answers = answers,
+        isSingleSelection = true,
+        onValueChange = onValueChange
+    )
+}
+
+@Composable
 private fun RatingBar(
     emojis: List<String>,
     answers: List<AnswerUiModel>,
+    isSingleSelection: Boolean = false,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -63,7 +91,7 @@ private fun RatingBar(
         modifier = modifier
     ) {
         items(emojis.size) { index ->
-            val isSelected = index <= selectedIndex
+            val isSelected = if (isSingleSelection) index == selectedIndex else index <= selectedIndex
             val alpha = if (isSelected) EMOJI_ALPHA_SELECTED else EMOJI_ALPHA_UNSELECTED
             Button(
                 onClick = {
@@ -107,6 +135,17 @@ fun HeartRatingBarPreview(
     @PreviewParameter(SurveyDetailParameterProvider::class) params: SurveyDetailParameterProvider.Params
 ) {
     HeartRatingBar(
+        answers = params.survey.questions[0].answers,
+        onValueChange = {},
+    )
+}
+
+@Preview
+@Composable
+fun SmileyRatingBarPreview(
+    @PreviewParameter(SurveyDetailParameterProvider::class) params: SurveyDetailParameterProvider.Params
+) {
+    SmileyRatingBar(
         answers = params.survey.questions[0].answers,
         onValueChange = {},
     )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/RatingBar.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/RatingBar.kt
@@ -96,7 +96,7 @@ private fun RatingBar(
             Button(
                 onClick = {
                     selectedIndex = index
-                    onValueChange(answers[selectedIndex].text)
+                    onValueChange(answers.getOrNull(selectedIndex)?.text.orEmpty())
                 },
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = Color.Transparent

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -117,7 +117,7 @@ private fun AnswerForm(
             DisplayType.SMILEY -> SmileyRatingBar(
                 answers = answers,
                 onValueChange = {
-                    Timber.d("$displayType -> onInputChange: $it")
+                    Timber.d("$displayType -> onValueChange: $it")
                 },
                 modifier = modifier
             )

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -114,6 +114,13 @@ private fun AnswerForm(
                 },
                 modifier = modifier
             )
+            DisplayType.SMILEY -> SmileyRatingBar(
+                answers = answers,
+                onValueChange = {
+                    Timber.d("$displayType -> onInputChange: $it")
+                },
+                modifier = modifier
+            )
             else -> Unit
         }
     }


### PR DESCRIPTION
- Close #32

## What happened 👀

Implement the `RatingBar` composable to produce the display type: `smiley` rating.

## Insight 📝

- Reuse `RatingBar` to build `smiley` rating.
- Add an option `isSingleSelection` to show single selection after selecting an item in Smiley rating.

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/216927899-3b6d7174-851d-4c3b-a304-f0b21c93f9a0.mp4

```
2023-02-06 15:57:26.935 11422-11422/vn.luongvo.kmm.survey.android.staging D/SurveyQuestionKt$AnswerForm: SMILEY -> onInputChange: 1
2023-02-06 15:57:27.280 11422-11422/vn.luongvo.kmm.survey.android.staging D/SurveyQuestionKt$AnswerForm: SMILEY -> onInputChange: 2
2023-02-06 15:57:27.602 11422-11422/vn.luongvo.kmm.survey.android.staging D/SurveyQuestionKt$AnswerForm: SMILEY -> onInputChange: 4
2023-02-06 15:57:27.906 11422-11422/vn.luongvo.kmm.survey.android.staging D/SurveyQuestionKt$AnswerForm: SMILEY -> onInputChange: 5
2023-02-06 15:57:28.288 11422-11422/vn.luongvo.kmm.survey.android.staging D/SurveyQuestionKt$AnswerForm: SMILEY -> onInputChange: 3
2023-02-06 15:57:28.609 11422-11422/vn.luongvo.kmm.survey.android.staging D/SurveyQuestionKt$AnswerForm: SMILEY -> onInputChange: 2
```
