### PR TITLE
[#28] [Android] [UI] As a user, I can see many question types: choice

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/MultipleChoices.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/MultipleChoices.kt
@@ -1,0 +1,113 @@
+package vn.luongvo.kmm.survey.android.ui.screens.survey.views
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.preview.SurveyDetailParameterProvider
+import vn.luongvo.kmm.survey.android.ui.screens.survey.*
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.dimensions
+import vn.luongvo.kmm.survey.android.ui.theme.AppTheme.typography
+
+@Composable
+fun MultipleChoices(
+    answers: List<AnswerUiModel>,
+    onValueChange: (List<String>) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedIndexes by remember { mutableStateOf(emptySet<Int>()) }
+    LazyColumn(modifier = modifier.padding(horizontal = 80.dp)) {
+        items(answers.size) { index ->
+            val isSelected = selectedIndexes.contains(index)
+
+            ChoiceItem(
+                answer = answers[index],
+                isSelected = isSelected,
+                onClick = {
+                    selectedIndexes = if (selectedIndexes.contains(index)) {
+                        selectedIndexes.minus(index)
+                    } else {
+                        selectedIndexes.plus(index)
+                    }
+                    onValueChange(selectedIndexes.map { answers[it].id })
+                }
+            )
+
+            if (index < answers.lastIndex) {
+                Spacer(
+                    modifier = Modifier
+                        .height(0.5.dp)
+                        .fillMaxWidth()
+                        .background(White)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoiceItem(
+    answer: AnswerUiModel,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = Transparent
+        ),
+        elevation = null,
+        contentPadding = PaddingValues(0.dp),
+        modifier = Modifier
+            .height(dimensions.inputHeight)
+            .fillMaxWidth()
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxSize()
+                .wrapContentHeight()
+        ) {
+            Text(
+                text = answer.text,
+                color = if (isSelected) White else White.copy(alpha = 0.5f),
+                style = if (isSelected) typography.h6 else typography.h6.copy(fontWeight = FontWeight.Normal),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            val imageResId =
+                if (isSelected) R.drawable.ic_checkbox_selected else R.drawable.ic_checkbox_unselected
+            Image(
+                painter = painterResource(id = imageResId),
+                contentDescription = null,
+                contentScale = ContentScale.FillWidth
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MultipleChoicesPreview(
+    @PreviewParameter(SurveyDetailParameterProvider::class) params: SurveyDetailParameterProvider.Params
+) {
+    MultipleChoices(
+        answers = params.survey.questions[0].answers,
+        onValueChange = {}
+    )
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/MultipleChoices.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/MultipleChoices.kt
@@ -29,21 +29,22 @@ fun MultipleChoices(
     onValueChange: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedIndexes by remember { mutableStateOf(emptySet<Int>()) }
+    var selectedIds by remember { mutableStateOf(emptySet<String>()) }
     LazyColumn(modifier = modifier.padding(horizontal = 80.dp)) {
         items(answers.size) { index ->
-            val isSelected = selectedIndexes.contains(index)
+            val answer = answers[index]
+            val isSelected = selectedIds.contains(answer.id)
 
             ChoiceItem(
-                answer = answers[index],
+                answer = answer,
                 isSelected = isSelected,
                 onClick = {
-                    selectedIndexes = if (selectedIndexes.contains(index)) {
-                        selectedIndexes.minus(index)
+                    selectedIds = if (selectedIds.contains(answer.id)) {
+                        selectedIds.minus(answer.id)
                     } else {
-                        selectedIndexes.plus(index)
+                        selectedIds.plus(answer.id)
                     }
-                    onValueChange(selectedIndexes.map { answers[it].id })
+                    onValueChange(selectedIds.toList())
                 }
             )
 

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -82,13 +82,17 @@ private fun SurveyQuestionContent(
             color = Color.White,
             style = AppTheme.typography.h4
         )
-        Spacer(modifier = Modifier.weight(1f))
-        AnswerForm(
-            question = question,
+        Box(
             modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-        )
-        Spacer(modifier = Modifier.weight(1f))
+                .fillMaxWidth()
+                .padding(vertical = dimensions.paddingSmall)
+                .weight(1f)
+        ) {
+            AnswerForm(
+                question = question,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
         if (index != count) {
             NextCircleButton(
                 onClick = onNextClick,

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/views/SurveyQuestion.kt
@@ -138,6 +138,13 @@ private fun AnswerForm(
                 },
                 modifier = modifier
             )
+            DisplayType.CHOICE -> MultipleChoices(
+                answers = answers,
+                onValueChange = {
+                    Timber.d("$displayType -> onValueChange: $it")
+                },
+                modifier = modifier
+            )
             DisplayType.NPS -> Nps(
                 answers = answers,
                 onValueChange = {

--- a/android/src/main/res/drawable/ic_checkbox_selected.xml
+++ b/android/src/main/res/drawable/ic_checkbox_selected.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="30dp"
+    android:viewportWidth="28"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M2,15C2,8.373 7.373,3 14,3C20.627,3 26,8.373 26,15C26,21.627 20.627,27 14,27C7.373,27 2,21.627 2,15Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd" />
+  <path
+      android:pathData="M12.554,17.242L19.005,10.791C19.393,10.403 20.021,10.403 20.409,10.791C20.797,11.179 20.797,11.807 20.409,12.195L12.554,20.051L7.991,15.488C7.603,15.1 7.603,14.472 7.991,14.084C8.379,13.696 9.007,13.696 9.395,14.084L12.554,17.242Z"
+      android:fillColor="#15151A" />
+</vector>

--- a/android/src/main/res/drawable/ic_checkbox_unselected.xml
+++ b/android/src/main/res/drawable/ic_checkbox_unselected.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="30dp"
+    android:viewportWidth="28"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M14,3C7.373,3 2,8.373 2,15C2,21.627 7.373,27 14,27C20.627,27 26,21.627 26,15C26,8.373 20.627,3 14,3ZM14,26C7.925,26 3,21.075 3,15C3,8.925 7.925,4 14,4C20.075,4 25,8.925 25,15C25,21.075 20.075,26 14,26Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd" />
+</vector>


### PR DESCRIPTION
- Close #28

## What happened 👀

Implement the `MultipleChoices` selector composable to produce the display type: choice.

## Insight 📝

- The `MultipleChoices` will return a list of selected item ids for submitting.
- Fix: wrap the `AnswerForm` into a `Box` to avoid long `AnswerForm` content that could kick the bottom button (Next, Submit) out of the screen.

## Proof Of Work 📹

https://user-images.githubusercontent.com/16315358/220514117-03d8cb86-6ab2-4eee-9e3d-256e8b954a99.mp4

```
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, bdf97897839888be159d]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, bdf97897839888be159d, 3fd673185845dce4aa7b]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, bdf97897839888be159d, 3fd673185845dce4aa7b, 2051cda19e6940173c9f]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, bdf97897839888be159d, 2051cda19e6940173c9f]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, 2051cda19e6940173c9f]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, 2051cda19e6940173c9f, 20907898b2c2d68159c8]
D/SurveyQuestionKt$AnswerForm: CHOICE -> onValueChange: [002d338bc37f2142ad44, 2051cda19e6940173c9f, 20907898b2c2d68159c8, 3fd673185845dce4aa7b]
```

- Fixed: long `AnswerForm` content.

https://user-images.githubusercontent.com/16315358/220557731-a8f9fe34-06bb-4efc-a137-95fcd055e228.mp4


