### PR TITLE
[#37] [#38] [Android] As a user, I can pull to refresh the survey list in Home screen

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.*
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
 import vn.luongvo.kmm.survey.android.ui.common.DimmedImageBackground
@@ -36,13 +35,13 @@ fun HomeScreen(
     navigator: (destination: AppDestination) -> Unit
 ) {
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
     val currentDate by viewModel.currentDate.collectAsStateWithLifecycle()
     val user by viewModel.user.collectAsStateWithLifecycle()
     val surveys by viewModel.surveys.collectAsStateWithLifecycle()
     val appVersion by viewModel.appVersion.collectAsStateWithLifecycle()
 
-    var isRefreshing by remember { mutableStateOf(false) }
     val scaffoldState = rememberScaffoldState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -70,13 +69,7 @@ fun HomeScreen(
         user = user,
         surveys = surveys,
         onSurveyClick = { survey -> viewModel.navigateToSurvey(survey?.id.orEmpty()) },
-        onRefresh = {
-            scope.launch {
-                isRefreshing = true
-                delay(1500)
-                isRefreshing = false
-            }
-        },
+        onRefresh = { viewModel.loadData(isRefresh = true) },
         onMenuLogoutClick = { viewModel.logOut() }
     )
 }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppColors.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/theme/AppColors.kt
@@ -3,6 +3,7 @@ package vn.luongvo.kmm.survey.android.ui.theme
 import androidx.compose.material.*
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.White
 
 /**
  * Extend final [Colors] class to provide more custom app colors.
@@ -10,7 +11,9 @@ import androidx.compose.ui.graphics.Color
 data class AppColors(
     val themeColors: Colors,
 
-    val drawerBackground: Color = Nero90
+    val drawerBackground: Color = Nero90,
+    val pullRefreshBackground: Color = White,
+    val pullRefreshContent: Color = Nero90,
 )
 
 internal val LightColorPalette = AppColors(

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -40,7 +40,7 @@ class HomeScreenTest {
     @Before
     fun setup() {
         every { mockGetUserProfileUseCase() } returns flowOf(user)
-        every { mockGetSurveysUseCase(any(), any()) } returns flowOf(surveys)
+        every { mockGetSurveysUseCase(any(), any(), any()) } returns flowOf(surveys)
         every { mockLogOutUseCase() } returns flowOf(Unit)
         every { mockDateFormatter.format(any(), any()) } returns "Thursday, December 29"
 
@@ -94,7 +94,7 @@ class HomeScreenTest {
     @Test
     fun `when getting surveys fails, it shows an error message`() {
         val expectedError = Throwable("unexpected error")
-        every { mockGetSurveysUseCase(any(), any()) } returns flow { throw expectedError }
+        every { mockGetSurveysUseCase(any(), any(), any()) } returns flow { throw expectedError }
 
         initComposable {
             onNodeWithText("unexpected error").assertIsDisplayed()

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -13,7 +13,8 @@ class SurveyRepositoryImpl(
     private val surveyRemoteDataSource: SurveyRemoteDataSource
 ) : SurveyRepository {
 
-    override fun getSurveys(pageNumber: Int, pageSize: Int): Flow<List<Survey>> = flowTransform {
+    override fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> = flowTransform {
+        // TODO clear surveys cache when isRefresh = true
         surveyRemoteDataSource
             .getSurveys(pageNumber = pageNumber, pageSize = pageSize)
             .map { it.toSurvey() }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
@@ -6,7 +6,7 @@ import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 
 interface SurveyRepository {
 
-    fun getSurveys(pageNumber: Int, pageSize: Int): Flow<List<Survey>>
+    fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>>
 
     fun getSurveyDetail(id: String): Flow<Survey>
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveysUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveysUseCase.kt
@@ -6,12 +6,12 @@ import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 interface GetSurveysUseCase {
 
-    operator fun invoke(pageNumber: Int, pageSize: Int): Flow<List<Survey>>
+    operator fun invoke(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>>
 }
 
 class GetSurveysUseCaseImpl(private val repository: SurveyRepository) : GetSurveysUseCase {
 
-    override operator fun invoke(pageNumber: Int, pageSize: Int): Flow<List<Survey>> {
-        return repository.getSurveys(pageNumber = pageNumber, pageSize = pageSize)
+    override operator fun invoke(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> {
+        return repository.getSurveys(pageNumber = pageNumber, pageSize = pageSize, isRefresh = isRefresh)
     }
 }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
@@ -37,7 +37,7 @@ class SurveyRepositoryTest {
             .whenInvokedWith(any(), any())
             .thenReturn(surveyResponses)
 
-        repository.getSurveys(pageNumber = 1, pageSize = 10).test {
+        repository.getSurveys(pageNumber = 1, pageSize = 10, isRefresh = false).test {
             awaitItem() shouldBe surveys
             awaitComplete()
         }
@@ -51,7 +51,7 @@ class SurveyRepositoryTest {
             .whenInvokedWith(any(), any())
             .thenThrow(throwable)
 
-        repository.getSurveys(pageNumber = 1, pageSize = 10).test {
+        repository.getSurveys(pageNumber = 1, pageSize = 10, isRefresh = false).test {
             awaitError() shouldBe throwable
         }
     }

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveysUseCaseTest.kt
@@ -29,10 +29,10 @@ class GetSurveysUseCaseTest {
     fun `when calling getSurveys successfully - it returns survey list`() = runTest {
         given(mockRepository)
             .function(mockRepository::getSurveys)
-            .whenInvokedWith(any(), any())
+            .whenInvokedWith(any(), any(), any())
             .thenReturn(flowOf(surveys))
 
-        useCase(pageNumber = 1, pageSize = 10).test {
+        useCase(pageNumber = 1, pageSize = 10, isRefresh = false).test {
             awaitItem() shouldBe surveys
             awaitComplete()
         }
@@ -43,12 +43,12 @@ class GetSurveysUseCaseTest {
         val throwable = Throwable()
         given(mockRepository)
             .function(mockRepository::getSurveys)
-            .whenInvokedWith(any(), any())
+            .whenInvokedWith(any(), any(), any())
             .thenReturn(
                 flow { throw throwable }
             )
 
-        useCase(pageNumber = 1, pageSize = 10).test {
+        useCase(pageNumber = 1, pageSize = 10, isRefresh = false).test {
             awaitError() shouldBe throwable
         }
     }


### PR DESCRIPTION
- Close #37
- Close #38

## What happened 👀

- Show pull to refresh indicator when pulling down on the Home screen.
- Reload the user profile & survey list on the Home screen when the user pulls down to refresh the screen content.

## Insight 📝

- Use [pullRefresh](https://developer.android.com/reference/kotlin/androidx/compose/material/pullrefresh/package-summary) modifier to implement the pull-to-refresh feature.
- `pullRefresh` needs a vertical scroll component to work, however, the Home screen contains horizontal pager, we need to wrap the screen content side a `LazyColumn`.

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/221430995-4d339a8e-752d-4f14-8ccb-c98dbe5428e0.mp4


