### PR TITLE
[#20] [Android] [Integrate] As a user, I can see the app cache and load survey list in Home screen

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeViewModel.kt
@@ -51,8 +51,7 @@ class HomeViewModel(
 
     private fun loadCachedSurveys() {
         getCachedSurveysUseCase()
-            .onStart { showLoading() }
-            .onCompletion { hideLoading() }
+            .injectLoading()
             .onEach { surveys ->
                 _surveys.emit(surveys.map { it.toUiModel() })
             }

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/util/DateFormatter.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/util/DateFormatter.kt
@@ -4,7 +4,6 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 interface DateFormatter {
-
     fun format(date: Date, dateFormat: String): String
 }
 

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/test/Fake.kt
@@ -48,5 +48,15 @@ object Fake {
         )
     )
 
+    val cachedSurveys = listOf(
+        Survey(
+            id = "1",
+            title = "Scarlett Bangkok",
+            description = "We'd love to hear from you!",
+            coverImageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_",
+            questions = null
+        )
+    )
+
     val surveyDetail = decodeFromJsonApiString<SurveyResponse>("survey_detail.json").toSurvey()
 }

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -31,6 +31,7 @@ class HomeScreenTest {
 
     private val mockGetUserProfileUseCase: GetUserProfileUseCase = mockk()
     private val mockGetSurveysUseCase: GetSurveysUseCase = mockk()
+    private val mockGetCachedSurveysUseCase: GetCachedSurveysUseCase = mockk()
     private val mockLogOutUseCase: LogOutUseCase = mockk()
     private val mockDateFormatter: DateFormatter = mockk()
 
@@ -41,12 +42,14 @@ class HomeScreenTest {
     fun setup() {
         every { mockGetUserProfileUseCase() } returns flowOf(user)
         every { mockGetSurveysUseCase(any(), any(), any()) } returns flowOf(surveys)
+        every { mockGetCachedSurveysUseCase() } returns flowOf(emptyList())
         every { mockLogOutUseCase() } returns flowOf(Unit)
         every { mockDateFormatter.format(any(), any()) } returns "Thursday, December 29"
 
         viewModel = HomeViewModel(
             mockGetUserProfileUseCase,
             mockGetSurveysUseCase,
+            mockGetCachedSurveysUseCase,
             mockLogOutUseCase,
             mockDateFormatter
         )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
         classpath(Dependencies.Kotlin.KOTLIN_GRADLE_PLUGIN)
         classpath(Dependencies.Kotlin.KOTLIN_SERIALIZATION)
         classpath(Dependencies.Firebase.GOOGLE_SERVICES)
+        classpath(Dependencies.Storage.REALM_GRADLE_PLUGIN)
     }
 }
 

--- a/buildSrc/src/main/java/Configurations.kt
+++ b/buildSrc/src/main/java/Configurations.kt
@@ -34,6 +34,8 @@ object Plugins {
     const val KSP = "com.google.devtools.ksp"
 
     const val MULTIPLATFORM = "multiplatform"
+
+    const val REALM = "io.realm.kotlin"
 }
 
 object XcodeConfiguration {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -50,6 +50,8 @@ object Versions {
 
     const val NAPIER = "2.6.1"
 
+    const val REALM = "1.6.1"
+
     const val SETTINGS = "1.0.0-RC"
 
     const val TIMBER = "4.7.1"
@@ -119,7 +121,10 @@ object Dependencies {
         const val JSON_API = "co.nimblehq.jsonapi:core:${Versions.JSON_API}"
     }
 
-    object Settings {
+    object Storage {
+        const val REALM_GRADLE_PLUGIN = "io.realm.kotlin:gradle-plugin:${Versions.REALM}"
+        const val REALM_CORE = "io.realm.kotlin:library-base:${Versions.REALM}"
+
         const val SETTINGS = "com.russhwolf:multiplatform-settings:${Versions.SETTINGS}"
     }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id(Plugins.KOVER)
     id(Plugins.KSP).version(Versions.KSP)
     id(Plugins.KOTLINX_RESOURCES).version(Versions.KOTLINX_RESOURCES)
+    id(Plugins.REALM)
 }
 
 kotlin {
@@ -48,7 +49,8 @@ kotlin {
                     implementation(AUTH)
                     implementation(JSON_API)
                 }
-                implementation(Dependencies.Settings.SETTINGS)
+                implementation(Dependencies.Storage.SETTINGS)
+                implementation(Dependencies.Storage.REALM_CORE)
                 implementation(Dependencies.Log.NAPIER)
             }
         }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
@@ -6,7 +6,6 @@ import io.realm.kotlin.ext.query
 import vn.luongvo.kmm.survey.data.local.model.SurveyRealmObject
 
 interface SurveyLocalDataSource {
-
     fun saveSurveys(surveys: List<SurveyRealmObject>)
 
     fun getSurveys(): List<SurveyRealmObject>

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
@@ -8,6 +8,8 @@ import vn.luongvo.kmm.survey.data.local.model.SurveyRealmObject
 interface SurveyLocalDataSource {
 
     fun saveSurveys(surveys: List<SurveyRealmObject>)
+
+    fun getSurveys(): List<SurveyRealmObject>
 }
 
 class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSource {
@@ -18,5 +20,9 @@ class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSourc
                 copyToRealm(it, updatePolicy = UpdatePolicy.ALL)
             }
         }
+    }
+
+    override fun getSurveys(): List<SurveyRealmObject> {
+        return realm.query<SurveyRealmObject>().find()
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
@@ -10,6 +10,8 @@ interface SurveyLocalDataSource {
     fun saveSurveys(surveys: List<SurveyRealmObject>)
 
     fun getSurveys(): List<SurveyRealmObject>
+
+    fun deleteAllSurveys()
 }
 
 class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSource {
@@ -24,5 +26,12 @@ class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSourc
 
     override fun getSurveys(): List<SurveyRealmObject> {
         return realm.query<SurveyRealmObject>().find()
+    }
+
+    override fun deleteAllSurveys() {
+        realm.writeBlocking {
+            val surveys = query<SurveyRealmObject>().find()
+            delete(surveys)
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
@@ -11,7 +11,7 @@ interface SurveyLocalDataSource {
 
     fun getSurveys(): List<SurveyRealmObject>
 
-    fun deleteAllSurveys()
+    fun clear()
 }
 
 class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSource {
@@ -28,7 +28,7 @@ class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSourc
         return realm.query<SurveyRealmObject>().find()
     }
 
-    override fun deleteAllSurveys() {
+    override fun clear() {
         realm.writeBlocking {
             val surveys = query<SurveyRealmObject>().find()
             delete(surveys)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/SurveyLocalDataSource.kt
@@ -1,0 +1,22 @@
+package vn.luongvo.kmm.survey.data.local.datasource
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.ext.query
+import vn.luongvo.kmm.survey.data.local.model.SurveyRealmObject
+
+interface SurveyLocalDataSource {
+
+    fun saveSurveys(surveys: List<SurveyRealmObject>)
+}
+
+class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSource {
+
+    override fun saveSurveys(surveys: List<SurveyRealmObject>) {
+        realm.writeBlocking {
+            surveys.forEach {
+                copyToRealm(it, updatePolicy = UpdatePolicy.ALL)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/datasource/TokenLocalDataSource.kt
@@ -8,7 +8,6 @@ private const val ACCESS_TOKEN_KEY = "accessToken"
 private const val REFRESH_TOKEN_KEY = "refreshToken"
 
 interface TokenLocalDataSource {
-
     fun saveToken(token: Token)
 
     fun clear()

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/model/SurveyRealmObject.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/model/SurveyRealmObject.kt
@@ -1,0 +1,36 @@
+package vn.luongvo.kmm.survey.data.local.model
+
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
+import vn.luongvo.kmm.survey.domain.model.Survey
+
+class SurveyRealmObject : RealmObject {
+
+    @PrimaryKey
+    var id: String = ""
+    var title: String = ""
+    var description: String = ""
+    var coverImageUrl: String = ""
+
+    constructor(
+        id: String,
+        title: String,
+        description: String,
+        coverImageUrl: String
+    ) : this() {
+        this.id = id
+        this.title = title
+        this.description = description
+        this.coverImageUrl = coverImageUrl
+    }
+
+    constructor()
+}
+
+fun SurveyRealmObject.toSurvey() = Survey(
+    id = id,
+    title = title,
+    description = description,
+    coverImageUrl = coverImageUrl,
+    questions = null
+)

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/realm/Realm.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/local/realm/Realm.kt
@@ -1,0 +1,10 @@
+package vn.luongvo.kmm.survey.data.local.realm
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import vn.luongvo.kmm.survey.data.local.model.SurveyRealmObject
+
+val realm: Realm by lazy {
+    val configuration = RealmConfiguration.create(schema = setOf(SurveyRealmObject::class))
+    Realm.open(configuration)
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/AuthRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/AuthRemoteDataSource.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.data.remote.model.request.*
 import vn.luongvo.kmm.survey.data.remote.model.response.TokenResponse
 
 interface AuthRemoteDataSource {
-
     suspend fun logIn(body: LoginRequestBody): TokenResponse
 
     suspend fun refreshToken(body: RefreshTokenRequestBody): TokenResponse

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/SurveyRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/SurveyRemoteDataSource.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.data.remote.model.request.SurveySubmissionRequestBo
 import vn.luongvo.kmm.survey.data.remote.model.response.SurveyResponse
 
 interface SurveyRemoteDataSource {
-
     suspend fun getSurveys(pageNumber: Int, pageSize: Int): List<SurveyResponse>
 
     suspend fun getSurveyDetail(id: String): SurveyResponse

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/UserRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/remote/datasource/UserRemoteDataSource.kt
@@ -4,7 +4,6 @@ import vn.luongvo.kmm.survey.data.remote.ApiClient
 import vn.luongvo.kmm.survey.data.remote.model.response.UserResponse
 
 interface UserRemoteDataSource {
-
     suspend fun getUserProfile(): UserResponse
 
     fun clearClientTokenConfig()

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -17,7 +17,7 @@ class SurveyRepositoryImpl(
 
     override fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> = flowTransform {
         if (isRefresh) {
-            surveyLocalDataSource.deleteAllSurveys()
+            surveyLocalDataSource.clear()
         }
 
         val surveys = surveyRemoteDataSource

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -3,6 +3,7 @@ package vn.luongvo.kmm.survey.data.repository
 import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.data.extensions.flowTransform
 import vn.luongvo.kmm.survey.data.local.datasource.SurveyLocalDataSource
+import vn.luongvo.kmm.survey.data.local.model.toSurvey
 import vn.luongvo.kmm.survey.data.remote.datasource.SurveyRemoteDataSource
 import vn.luongvo.kmm.survey.data.remote.model.request.SurveySubmissionRequestBody
 import vn.luongvo.kmm.survey.data.remote.model.response.toSurvey
@@ -23,6 +24,12 @@ class SurveyRepositoryImpl(
         surveyLocalDataSource.saveSurveys(surveys.map { it.toSurveyRealmObject() })
 
         surveys
+    }
+
+    override fun getCachedSurveys(): Flow<List<Survey>> = flowTransform {
+        surveyLocalDataSource
+            .getSurveys()
+            .map { it.toSurvey() }
     }
 
     override fun getSurveyDetail(id: String): Flow<Survey> = flowTransform {

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -16,7 +16,10 @@ class SurveyRepositoryImpl(
 ) : SurveyRepository {
 
     override fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> = flowTransform {
-        // TODO clear surveys cache when isRefresh = true
+        if (isRefresh) {
+            surveyLocalDataSource.deleteAllSurveys()
+        }
+
         val surveys = surveyRemoteDataSource
             .getSurveys(pageNumber = pageNumber, pageSize = pageSize)
             .map { it.toSurvey() }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -16,14 +16,13 @@ class SurveyRepositoryImpl(
 ) : SurveyRepository {
 
     override fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> = flowTransform {
-        if (isRefresh) {
-            surveyLocalDataSource.clear()
-        }
-
         val surveys = surveyRemoteDataSource
             .getSurveys(pageNumber = pageNumber, pageSize = pageSize)
             .map { it.toSurvey() }
 
+        if (isRefresh) {
+            surveyLocalDataSource.clear()
+        }
         surveyLocalDataSource.saveSurveys(surveys.map { it.toSurveyRealmObject() })
 
         surveys

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryImpl.kt
@@ -2,22 +2,27 @@ package vn.luongvo.kmm.survey.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.data.extensions.flowTransform
+import vn.luongvo.kmm.survey.data.local.datasource.SurveyLocalDataSource
 import vn.luongvo.kmm.survey.data.remote.datasource.SurveyRemoteDataSource
 import vn.luongvo.kmm.survey.data.remote.model.request.SurveySubmissionRequestBody
 import vn.luongvo.kmm.survey.data.remote.model.response.toSurvey
-import vn.luongvo.kmm.survey.domain.model.Survey
-import vn.luongvo.kmm.survey.domain.model.SurveySubmission
+import vn.luongvo.kmm.survey.domain.model.*
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 class SurveyRepositoryImpl(
-    private val surveyRemoteDataSource: SurveyRemoteDataSource
+    private val surveyRemoteDataSource: SurveyRemoteDataSource,
+    private val surveyLocalDataSource: SurveyLocalDataSource
 ) : SurveyRepository {
 
     override fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> = flowTransform {
         // TODO clear surveys cache when isRefresh = true
-        surveyRemoteDataSource
+        val surveys = surveyRemoteDataSource
             .getSurveys(pageNumber = pageNumber, pageSize = pageSize)
             .map { it.toSurvey() }
+
+        surveyLocalDataSource.saveSurveys(surveys.map { it.toSurveyRealmObject() })
+
+        surveys
     }
 
     override fun getSurveyDetail(id: String): Flow<Survey> = flowTransform {

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/LocalModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/LocalModule.kt
@@ -3,9 +3,11 @@ package vn.luongvo.kmm.survey.di.module
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
-import vn.luongvo.kmm.survey.data.local.datasource.TokenLocalDataSource
-import vn.luongvo.kmm.survey.data.local.datasource.TokenLocalDataSourceImpl
+import vn.luongvo.kmm.survey.data.local.datasource.*
+import vn.luongvo.kmm.survey.data.local.realm.realm
 
 val localModule = module {
+    single { realm }
     singleOf(::TokenLocalDataSourceImpl) { bind<TokenLocalDataSource>() }
+    singleOf(::SurveyLocalDataSourceImpl) { bind<SurveyLocalDataSource>() }
 }

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/di/module/UseCaseModule.kt
@@ -11,6 +11,7 @@ val useCaseModule = module {
     singleOf(::GetUserProfileUseCaseImpl) bind GetUserProfileUseCase::class
     singleOf(::RefreshTokenUseCaseImpl) bind RefreshTokenUseCase::class
     singleOf(::GetSurveysUseCaseImpl) bind GetSurveysUseCase::class
+    singleOf(::GetCachedSurveysUseCaseImpl) bind GetCachedSurveysUseCase::class
     singleOf(::GetSurveyDetailUseCaseImpl) bind GetSurveyDetailUseCase::class
     singleOf(::LogOutUseCaseImpl) bind LogOutUseCase::class
     singleOf(::SubmitSurveyUseCaseImpl) bind SubmitSurveyUseCase::class

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/model/Survey.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/model/Survey.kt
@@ -1,9 +1,18 @@
 package vn.luongvo.kmm.survey.domain.model
 
+import vn.luongvo.kmm.survey.data.local.model.SurveyRealmObject
+
 data class Survey(
     val id: String,
     val title: String,
     val description: String,
     val coverImageUrl: String,
     val questions: List<Question>?
+)
+
+fun Survey.toSurveyRealmObject() = SurveyRealmObject(
+    id = id,
+    title = title,
+    description = description,
+    coverImageUrl = coverImageUrl
 )

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/AuthRepository.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.domain.model.Token
 
 interface AuthRepository {
-
     fun logIn(email: String, password: String): Flow<Token>
 
     fun refreshToken(refreshToken: String): Flow<Token>

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.model.Survey
 import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 
 interface SurveyRepository {
-
     fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>>
 
     fun getCachedSurveys(): Flow<List<Survey>>

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/SurveyRepository.kt
@@ -8,6 +8,8 @@ interface SurveyRepository {
 
     fun getSurveys(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>>
 
+    fun getCachedSurveys(): Flow<List<Survey>>
+
     fun getSurveyDetail(id: String): Flow<Survey>
 
     fun submitSurvey(submission: SurveySubmission): Flow<Unit>

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/repository/UserRepository.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.domain.model.User
 
 interface UserRepository {
-
     fun getUserProfile(): Flow<User>
 
     fun clearClientTokenConfig()

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetCachedSurveysUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetCachedSurveysUseCase.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.model.Survey
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 interface GetCachedSurveysUseCase {
-
     operator fun invoke(): Flow<List<Survey>>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetCachedSurveysUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetCachedSurveysUseCase.kt
@@ -1,0 +1,17 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import vn.luongvo.kmm.survey.domain.model.Survey
+import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
+
+interface GetCachedSurveysUseCase {
+
+    operator fun invoke(): Flow<List<Survey>>
+}
+
+class GetCachedSurveysUseCaseImpl(private val repository: SurveyRepository) : GetCachedSurveysUseCase {
+
+    override operator fun invoke(): Flow<List<Survey>> {
+        return repository.getCachedSurveys()
+    }
+}

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveyDetailUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveyDetailUseCase.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.model.Survey
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 interface GetSurveyDetailUseCase {
-
     operator fun invoke(id: String): Flow<Survey>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveysUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetSurveysUseCase.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.model.Survey
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 interface GetSurveysUseCase {
-
     operator fun invoke(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetUserProfileUseCase.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.model.User
 import vn.luongvo.kmm.survey.domain.repository.UserRepository
 
 interface GetUserProfileUseCase {
-
     operator fun invoke(): Flow<User>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/IsLoggedInUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/IsLoggedInUseCase.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.Flow
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 
 interface IsLoggedInUseCase {
-
     operator fun invoke(): Flow<Boolean>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogInUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogInUseCase.kt
@@ -6,7 +6,6 @@ import vn.luongvo.kmm.survey.domain.model.Token
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 
 interface LogInUseCase {
-
     operator fun invoke(email: String, password: String): Flow<Token>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/LogOutUseCase.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 import vn.luongvo.kmm.survey.domain.repository.UserRepository
 
 interface LogOutUseCase {
-
     operator fun invoke(): Flow<Unit>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/RefreshTokenUseCase.kt
@@ -6,7 +6,6 @@ import vn.luongvo.kmm.survey.domain.model.Token
 import vn.luongvo.kmm.survey.domain.repository.AuthRepository
 
 interface RefreshTokenUseCase {
-
     operator fun invoke(refreshToken: String): Flow<Token>
 }
 

--- a/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/SubmitSurveyUseCase.kt
+++ b/shared/src/commonMain/kotlin/vn/luongvo/kmm/survey/domain/usecase/SubmitSurveyUseCase.kt
@@ -5,7 +5,6 @@ import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
 
 interface SubmitSurveyUseCase {
-
     operator fun invoke(submission: SurveySubmission): Flow<Unit>
 }
 

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
@@ -56,6 +56,23 @@ class SurveyRepositoryTest {
     }
 
     @Test
+    fun `when calling getSurveys with isRefresh = true - it clears the cache`() = runTest {
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::getSurveys)
+            .whenInvokedWith(any(), any())
+            .thenReturn(surveyResponses)
+
+        repository.getSurveys(pageNumber = 1, pageSize = 10, isRefresh = true).test {
+            awaitItem() shouldBe surveys
+            awaitComplete()
+
+            verify(mockLocalDataSource)
+                .function(mockLocalDataSource::clear)
+                .wasInvoked(exactly = 1.time)
+        }
+    }
+
+    @Test
     fun `when calling getSurveys fails - it does not cache and throws the corresponding error`() = runTest {
         val throwable = Throwable()
         given(mockRemoteDataSource)

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
@@ -5,12 +5,15 @@ import io.kotest.matchers.shouldBe
 import io.mockative.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.data.local.datasource.SurveyLocalDataSource
 import vn.luongvo.kmm.survey.data.remote.datasource.SurveyRemoteDataSource
 import vn.luongvo.kmm.survey.domain.model.SurveySubmission
 import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
+import vn.luongvo.kmm.survey.test.Fake.cachedSurveys
 import vn.luongvo.kmm.survey.test.Fake.surveyDetail
 import vn.luongvo.kmm.survey.test.Fake.surveyDetailResponse
 import vn.luongvo.kmm.survey.test.Fake.surveyResponses
+import vn.luongvo.kmm.survey.test.Fake.surveySurveyRealmObjects
 import vn.luongvo.kmm.survey.test.Fake.surveys
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -19,39 +22,79 @@ import kotlin.test.Test
 class SurveyRepositoryTest {
 
     @Mock
-    private val mockDataSource = mock(SurveyRemoteDataSource::class)
+    private val mockRemoteDataSource = mock(SurveyRemoteDataSource::class)
+
+    @Mock
+    private val mockLocalDataSource = mock(SurveyLocalDataSource::class)
 
     private lateinit var repository: SurveyRepository
 
     @BeforeTest
     fun setUp() {
         repository = SurveyRepositoryImpl(
-            mockDataSource
+            mockRemoteDataSource,
+            mockLocalDataSource
         )
     }
 
     @Test
-    fun `when calling getSurveys successfully - it returns survey list`() = runTest {
-        given(mockDataSource)
-            .suspendFunction(mockDataSource::getSurveys)
+    fun `when calling getSurveys successfully - it caches and returns survey list`() = runTest {
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::getSurveys)
             .whenInvokedWith(any(), any())
             .thenReturn(surveyResponses)
 
         repository.getSurveys(pageNumber = 1, pageSize = 10, isRefresh = false).test {
             awaitItem() shouldBe surveys
             awaitComplete()
+
+            verify(mockLocalDataSource)
+                .function(mockLocalDataSource::saveSurveys)
+                .with(any())
+                .wasInvoked(exactly = 1.time)
         }
     }
 
     @Test
-    fun `when calling getSurveys fails - it throws the corresponding error`() = runTest {
+    fun `when calling getSurveys fails - it does not cache and throws the corresponding error`() = runTest {
         val throwable = Throwable()
-        given(mockDataSource)
-            .suspendFunction(mockDataSource::getSurveys)
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::getSurveys)
             .whenInvokedWith(any(), any())
             .thenThrow(throwable)
 
         repository.getSurveys(pageNumber = 1, pageSize = 10, isRefresh = false).test {
+            awaitError() shouldBe throwable
+
+            verify(mockLocalDataSource)
+                .function(mockLocalDataSource::saveSurveys)
+                .with(any())
+                .wasInvoked(exactly = 0.time)
+        }
+    }
+
+    @Test
+    fun `when calling getCachedSurveys successfully - it returns cached survey list`() = runTest {
+        given(mockLocalDataSource)
+            .function(mockLocalDataSource::getSurveys)
+            .whenInvoked()
+            .thenReturn(surveySurveyRealmObjects)
+
+        repository.getCachedSurveys().test {
+            awaitItem() shouldBe cachedSurveys
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling getCachedSurveys fails - it throws the corresponding error`() = runTest {
+        val throwable = Throwable()
+        given(mockLocalDataSource)
+            .function(mockLocalDataSource::getSurveys)
+            .whenInvoked()
+            .thenThrow(throwable)
+
+        repository.getCachedSurveys().test {
             awaitError() shouldBe throwable
         }
     }
@@ -60,8 +103,8 @@ class SurveyRepositoryTest {
     fun `when calling getSurveyDetail successfully - it returns the survey detail`() = runTest {
         println(surveyDetailResponse)
 
-        given(mockDataSource)
-            .suspendFunction(mockDataSource::getSurveyDetail)
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::getSurveyDetail)
             .whenInvokedWith(any())
             .thenReturn(surveyDetailResponse)
 
@@ -74,8 +117,8 @@ class SurveyRepositoryTest {
     @Test
     fun `when calling getSurveyDetail fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
-        given(mockDataSource)
-            .suspendFunction(mockDataSource::getSurveyDetail)
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::getSurveyDetail)
             .whenInvokedWith(any())
             .thenThrow(throwable)
 
@@ -86,8 +129,8 @@ class SurveyRepositoryTest {
 
     @Test
     fun `when calling submitSurvey successfully - it returns Unit`() = runTest {
-        given(mockDataSource)
-            .suspendFunction(mockDataSource::submitSurvey)
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::submitSurvey)
             .whenInvokedWith(any())
             .thenReturn(Unit)
 
@@ -105,8 +148,8 @@ class SurveyRepositoryTest {
     @Test
     fun `when calling submitSurvey fails - it throws the corresponding error`() = runTest {
         val throwable = Throwable()
-        given(mockDataSource)
-            .suspendFunction(mockDataSource::submitSurvey)
+        given(mockRemoteDataSource)
+            .suspendFunction(mockRemoteDataSource::submitSurvey)
             .whenInvokedWith(any())
             .thenThrow(throwable)
 

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetCachedSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/domain/usecase/GetCachedSurveysUseCaseTest.kt
@@ -1,0 +1,55 @@
+package vn.luongvo.kmm.survey.domain.usecase
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import vn.luongvo.kmm.survey.domain.repository.SurveyRepository
+import vn.luongvo.kmm.survey.test.Fake.surveys
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class GetCachedSurveysUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(SurveyRepository::class)
+
+    private lateinit var useCase: GetCachedSurveysUseCase
+
+    @BeforeTest
+    fun setUp() {
+        useCase = GetCachedSurveysUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when calling getCachedSurveys successfully - it returns survey list`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::getCachedSurveys)
+            .whenInvoked()
+            .thenReturn(flowOf(surveys))
+
+        useCase().test {
+            awaitItem() shouldBe surveys
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when calling getCachedSurveys fails - it throws the corresponding error`() = runTest {
+        val throwable = Throwable()
+        given(mockRepository)
+            .function(mockRepository::getCachedSurveys)
+            .whenInvoked()
+            .thenReturn(
+                flow { throw throwable }
+            )
+
+        useCase().test {
+            awaitError() shouldBe throwable
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/test/Fake.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/test/Fake.kt
@@ -5,6 +5,8 @@ import co.nimblehq.jsonapi.model.JsonApiError
 import co.nimblehq.jsonapi.model.JsonApiException
 import com.goncalossilva.resources.Resource
 import kotlinx.serialization.json.Json
+import vn.luongvo.kmm.survey.data.local.model.SurveyRealmObject
+import vn.luongvo.kmm.survey.data.local.model.toSurvey
 import vn.luongvo.kmm.survey.data.remote.model.response.*
 
 object Fake {
@@ -34,6 +36,17 @@ object Fake {
         decodeFromJsonApiString("src/commonTest/resources/surveys.json")
 
     val surveys = surveyResponses.map { it.toSurvey() }
+
+    val surveySurveyRealmObjects: List<SurveyRealmObject> = listOf(
+        SurveyRealmObject(
+            id = "id",
+            title = "title",
+            description = "description",
+            coverImageUrl = "coverImageUrl"
+        )
+    )
+
+    val cachedSurveys = surveySurveyRealmObjects.map { it.toSurvey() }
 
     val surveyDetailResponse: SurveyResponse =
         decodeFromJsonApiString("src/commonTest/resources/survey_detail.json")


### PR DESCRIPTION
- Close #20

## What happened 👀

- Implement the local storage to cache the survey data.
- Save & load the cache survey on the Home screen. The `shimmer` loading will display one time from both continuous steps: survey loading from the cache & survey loading from the remote API.
- Clear cache when refreshing the Home screen.

## Insight 📝

- At first, I intended to use [sqldelight](https://cashapp.github.io/sqldelight/2.0.0-alpha05/multiplatform_sqlite/) but it seems to be too complicated & unfriendly. In the end, [realm-kotlin](https://github.com/realm/realm-kotlin) is a better choice.
- I created a new use case `GetCachedSurveysUseCase` to ease the `shimmer` loading logic control.

## Proof Of Work 📹

- First-time app open > no cache > the shimmer loading shows on the survey API call.


https://user-images.githubusercontent.com/16315358/222981566-f041b438-f9de-4923-b571-df8a389dcb8f.mp4



- Next-times app open > pre-load survey list with cached survey > the shimmer loading does not show on the survey API call.


https://user-images.githubusercontent.com/16315358/222981571-78ae8a32-6e7a-49f5-aa46-b3601a73f01b.mp4

