### PR TITLE
[#36] Show the confirmation dialog when clicking on Close survey button

### DIFF
--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/ConfirmationDialog.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/common/ConfirmationDialog.kt
@@ -1,0 +1,61 @@
+package vn.luongvo.kmm.survey.android.ui.common
+
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import vn.luongvo.kmm.survey.android.R
+import vn.luongvo.kmm.survey.android.ui.theme.Nero90
+
+@Composable
+fun ConfirmationDialog(
+    title: String,
+    message: String,
+    onDismissRequest: () -> Unit,
+    onConfirmButtonClick: () -> Unit = onDismissRequest,
+    onDismissButtonClick: () -> Unit = onDismissRequest
+) {
+    AlertDialog(
+        title = { Text(text = title) },
+        text = { Text(text = message) },
+        backgroundColor = White,
+        confirmButton = {
+            Button(
+                onClick = { onConfirmButtonClick() },
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Nero90
+                ),
+            ) {
+                Text(
+                    text = stringResource(id = R.string.generic_yes),
+                    color = White
+                )
+            }
+        },
+        dismissButton = {
+            Button(
+                onClick = { onDismissButtonClick() },
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Nero90
+                ),
+            ) {
+                Text(
+                    text = stringResource(id = R.string.generic_no),
+                    color = White
+                )
+            }
+        },
+        onDismissRequest = { onDismissRequest() }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ConfirmationDialogPreview() {
+    ConfirmationDialog(
+        title = "Title",
+        message = "Message",
+        onDismissRequest = {}
+    )
+}

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -1,5 +1,6 @@
 package vn.luongvo.kmm.survey.android.ui.screens.survey
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
@@ -53,19 +54,10 @@ fun SurveyScreen(
     }
 
     val showConfirmationDialog = remember { mutableStateOf(false) }
-    if (showConfirmationDialog.value) {
-        ConfirmationDialog(
-            title = stringResource(id = R.string.survey_quit_confirmation_title),
-            message = stringResource(id = R.string.survey_quit_confirmation_description),
-            onConfirmButtonClick = {
-                showConfirmationDialog.value = false
-                navigator(AppDestination.Up)
-            },
-            onDismissRequest = {
-                showConfirmationDialog.value = false
-            }
-        )
-    }
+    ConfirmationDialogHandling(
+        showConfirmationDialog = showConfirmationDialog,
+        onExit = { navigator(AppDestination.Up) }
+    )
 
     LaunchedEffect(Unit) {
         viewModel.getSurveyDetail(id = surveyId)
@@ -83,6 +75,30 @@ fun SurveyScreen(
         onAnswer = { viewModel.saveAnswerForQuestion(it) },
         onSubmitClick = { viewModel.submitSurvey() }
     )
+}
+
+@Composable
+private fun ConfirmationDialogHandling(
+    showConfirmationDialog: MutableState<Boolean>,
+    onExit: () -> Unit,
+) {
+    if (showConfirmationDialog.value) {
+        ConfirmationDialog(
+            title = stringResource(id = R.string.survey_quit_confirmation_title),
+            message = stringResource(id = R.string.survey_quit_confirmation_description),
+            onConfirmButtonClick = {
+                showConfirmationDialog.value = false
+                onExit()
+            },
+            onDismissRequest = {
+                showConfirmationDialog.value = false
+            }
+        )
+    }
+    // Override the system back button
+    BackHandler(true) {
+        showConfirmationDialog.value = true
+    }
 }
 
 @OptIn(ExperimentalPagerApi::class)

--- a/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
+++ b/android/src/main/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
@@ -13,6 +14,7 @@ import com.google.accompanist.pager.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
+import vn.luongvo.kmm.survey.android.R
 import vn.luongvo.kmm.survey.android.ui.common.*
 import vn.luongvo.kmm.survey.android.ui.navigation.AppDestination
 import vn.luongvo.kmm.survey.android.ui.preview.*
@@ -50,6 +52,21 @@ fun SurveyScreen(
         viewModel.clearError()
     }
 
+    val showConfirmationDialog = remember { mutableStateOf(false) }
+    if (showConfirmationDialog.value) {
+        ConfirmationDialog(
+            title = stringResource(id = R.string.survey_quit_confirmation_title),
+            message = stringResource(id = R.string.survey_quit_confirmation_description),
+            onConfirmButtonClick = {
+                showConfirmationDialog.value = false
+                navigator(AppDestination.Up)
+            },
+            onDismissRequest = {
+                showConfirmationDialog.value = false
+            }
+        )
+    }
+
     LaunchedEffect(Unit) {
         viewModel.getSurveyDetail(id = surveyId)
     }
@@ -62,7 +79,7 @@ fun SurveyScreen(
         scaffoldState = scaffoldState,
         isLoading = isLoading,
         survey = survey,
-        onBackClick = { navigator(AppDestination.Up) },
+        onBackClick = { showConfirmationDialog.value = true },
         onAnswer = { viewModel.saveAnswerForQuestion(it) },
         onSubmitClick = { viewModel.submitSurvey() }
     )

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -5,7 +5,9 @@
     <string name="completion_thanks_message">Thanks for taking the survey.</string>
 
     <string name="generic_error">Unexpected error!</string>
+    <string name="generic_no">No</string>
     <string name="generic_ok">OK</string>
+    <string name="generic_yes">Yes</string>
 
     <string name="home_logout">Logout</string>
     <string name="home_today">Today</string>
@@ -20,4 +22,6 @@
 
     <string name="survey_start">Start Survey</string>
     <string name="survey_submit">Submit</string>
+    <string name="survey_quit_confirmation_description">Are you sure you want to quit the survey?</string>
+    <string name="survey_quit_confirmation_title">Warning</string>
 </resources>

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/home/HomeScreenTest.kt
@@ -5,12 +5,12 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.*
-import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.koin.core.context.stopKoin
 import vn.luongvo.kmm.survey.android.R
@@ -108,7 +108,7 @@ class HomeScreenTest {
     fun `when clicking on the Next button on each survey, it navigates to the Survey screen`() = initComposable {
         onNodeWithContentDescription(HomeSurveyDetail).performClick()
 
-        assertEquals(expectedAppDestination, AppDestination.Survey)
+        expectedAppDestination shouldBe AppDestination.Survey
     }
 
     private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/login/LoginScreenTest.kt
@@ -5,12 +5,12 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.*
-import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.koin.core.context.stopKoin
 import vn.luongvo.kmm.survey.android.R
@@ -68,7 +68,7 @@ class LoginScreenTest {
         every { mockIsLoggedInUseCase() } returns flowOf(true)
         initComposable {
             waitForIdle()
-            assertEquals(expectedAppDestination, AppDestination.Home)
+            expectedAppDestination shouldBe AppDestination.Home
         }
     }
 
@@ -80,7 +80,7 @@ class LoginScreenTest {
         onNodeWithContentDescription(LoginPasswordField).performTextInput("12345678")
         onNodeWithContentDescription(LoginButton).performClick()
 
-        assertEquals(expectedAppDestination, AppDestination.Home)
+        expectedAppDestination shouldBe AppDestination.Home
     }
 
     @Test

--- a/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreenTest.kt
+++ b/android/src/test/java/vn/luongvo/kmm/survey/android/ui/screens/survey/SurveyScreenTest.kt
@@ -5,12 +5,12 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.*
-import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.koin.core.context.stopKoin
 import vn.luongvo.kmm.survey.android.R
@@ -60,7 +60,7 @@ class SurveyScreenTest {
 
             testAndFillQuestionAnswers()
 
-            assertEquals(expectedAppDestination, AppDestination.Completion)
+            expectedAppDestination shouldBe AppDestination.Completion
         }
 
     private fun ComposeContentTestRule.testAndFillQuestionAnswers() {
@@ -129,11 +129,20 @@ class SurveyScreenTest {
     }
 
     @Test
-    fun `when clicking on the Back button, it navigates back to the Home screen`() = initComposable {
-        onNodeWithContentDescription(SurveyBackButton).performClick()
+    fun `when clicking on the Back button, it shows the confirmation dialog to navigate back to the Home screen`() =
+        initComposable {
+            onNodeWithContentDescription(SurveyBackButton).performClick()
+            onNodeWithText(context.getString(R.string.generic_no)).performClick()
 
-        assertEquals(expectedAppDestination, AppDestination.Up)
-    }
+            // Cancel and stay on the Survey screen
+            expectedAppDestination shouldBe null
+
+            onNodeWithContentDescription(SurveyBackButton).performClick()
+            onNodeWithText(context.getString(R.string.generic_yes)).performClick()
+
+            // Navigate back to the Home screen
+            expectedAppDestination shouldBe AppDestination.Up
+        }
 
     @Test
     fun `when getting survey detail fails, it shows an error message`() {

--- a/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/vn/luongvo/kmm/survey/data/repository/SurveyRepositoryTest.kt
@@ -18,6 +18,7 @@ import vn.luongvo.kmm.survey.test.Fake.surveys
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
+@Suppress("TooManyFunctions", "LargeClass")
 @ExperimentalCoroutinesApi
 class SurveyRepositoryTest {
 


### PR DESCRIPTION
- Close #36

## What happened 👀

Show the confirmation dialog when clicking on the `Close survey` button or pressing the `back gesture`.

## Insight 📝

- Clone `AlertDialog` to have a new `ConfirmationDialog` for the confirmation dialog.
- Use [BackHandler](https://developer.android.com/reference/kotlin/androidx/activity/compose/package-summary#BackHandler(kotlin.Boolean,kotlin.Function0)) to override the system back button to show the dialog.

## Proof Of Work 📹



https://user-images.githubusercontent.com/16315358/223091583-3ad4de3f-a499-4c4b-a8bc-650f5fb08bc2.mp4

