### PR TITLE
Add Play Store app publishing

### DIFF
--- a/.github/workflows/android_deploy_production_build.yml
+++ b/.github/workflows/android_deploy_production_build.yml
@@ -54,30 +54,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run unit tests with Kover
-        run: ./gradlew koverMergedXmlReport
-
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: ./build/reports/kover/merged/xml/report.xml
-          flags: unittests # optional
-          fail_ci_if_error: false
-          verbose: true
-
       - uses: chkfung/android-version-actions@v1.1
         with:
           gradlePath: android/build.gradle.kts
           versionCode: ${{ github.run_number }}
 
-      - name: Build Production release APK
-        run: ./gradlew assembleProductionRelease
+      - name: Build the Production App Bundle
+        run: ./gradlew bundleProductionRelease
 
-      - name: Deploy staging to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+      - name: Read the current version
+        id: version
+        run: echo "version=$(perl -nle 'print $1 if /ANDROID_VERSION_NAME = \"(.*)\"$/' buildSrc/src/main/java/Dependencies.kt)" >> $GITHUB_OUTPUT
+
+      - name: Upload the Android Production bundle to the Play Store
+        uses: r0adkll/upload-google-play@v1
         with:
-          appId: '1:835959262689:android:cfc4c7eb6425a49c0896a0'
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
-          groups: nimble
-          file: android/build/outputs/apk/production/release/android-production-release.apk
+          releaseFiles: android/build/outputs/bundle/productionRelease/android-production-release.aab
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: vn.luongvo.kmm.survey.android
+          releaseName: ${{ steps.version.outputs.version }}
+          track: internal
+          status: draft
+          whatsNewDirectory: .github/workflows/whatsnew

--- a/.github/workflows/android_deploy_staging_build.yml
+++ b/.github/workflows/android_deploy_staging_build.yml
@@ -39,18 +39,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run unit tests with Kover
-        run: ./gradlew koverMergedXmlReport
-
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: ./build/reports/kover/merged/xml/report.xml
-          flags: unittests # optional
-          fail_ci_if_error: false
-          verbose: true
-
       - uses: chkfung/android-version-actions@v1.1
         with:
           gradlePath: android/build.gradle.kts

--- a/.github/workflows/whatsnew/whatsnew-en-US
+++ b/.github/workflows/whatsnew/whatsnew-en-US
@@ -1,0 +1,1 @@
+Enter or paste your release notes for en-US here


### PR DESCRIPTION
## What happened 👀

- Add Play Store app publishing

## Insight 📝

- Create the new app, choose `Let Google manage and protect your app signing key (recommended)` for App signing setting.
- Create the Service Account from the Google Play Developer API https://help.radio.co/en/articles/6232140-how-to-get-your-google-play-json-key
- Add the Service Account as a User at `Users and permissions`
	- `The caller does not have permission` error ❌ https://github.com/fastlane/fastlane/issues/16164#issuecomment-650812102
	
		> after creating your service account, you need to add it as Release Manager on the Google Play Console under Users & permissions -> Invite New User and use the email of your service account from the Google Developers Console. Add User to complete the process �

## Proof Of Work 📹

https://github.com/luongvo/kmm-survey/actions/runs/7629458414/job/20782905039 ✅ 

<img width="769" alt="image" src="https://github.com/luongvo/kmm-survey/assets/16315358/01fd9667-d00b-4e7b-a2c2-a0af6b6ad1db">


<img width="1471" alt="image" src="https://github.com/luongvo/kmm-survey/assets/16315358/e73afb98-ad78-41eb-9940-d4a96eb7efa1">


